### PR TITLE
[codex] Keep clawdex init local-only by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ Local-first contact crawler and markdown archive CLI.
 `clawdex` is a local-first contact crawler and markdown archive CLI. The app lives in this
 repo; your contacts live in a separate private Git-backed markdown repo.
 
-The default backup remote is:
+Contacts stay local by default. To back up or sync across machines, configure a
+private Git remote you own:
 
 ```bash
-https://github.com/steipete/backup-clawdex.git
+https://github.com/<you>/backup-clawdex.git
 ```
 
 ## Setup
@@ -28,7 +29,13 @@ go install github.com/openclaw/clawdex/cmd/clawdex@latest
 ```bash
 clawdex init ~/.clawdex/contacts
 clawdex config set repo_path ~/.clawdex/contacts
-clawdex config set git.remote https://github.com/steipete/backup-clawdex.git
+clawdex config set git.remote https://github.com/<you>/backup-clawdex.git
+```
+
+Or set the backup remote during initialization:
+
+```bash
+clawdex init ~/.clawdex/contacts --remote https://github.com/<you>/backup-clawdex.git
 ```
 
 `init` creates a data repo:

--- a/cmd/clawdex/main_test.go
+++ b/cmd/clawdex/main_test.go
@@ -12,7 +12,7 @@ func TestRun(t *testing.T) {
 	var out, errOut bytes.Buffer
 	cfg := filepath.Join(t.TempDir(), "config.toml")
 	code := run([]string{"--config", cfg, "config"}, &out, &errOut)
-	if code != 0 || !strings.Contains(out.String(), "backup-clawdex") {
+	if code != 0 || strings.Contains(out.String(), "steipete") {
 		t.Fatalf("code=%d out=%s err=%s", code, out.String(), errOut.String())
 	}
 	code = run([]string{"--bogus"}, &out, &errOut)

--- a/cmd/clawdex/main_test.go
+++ b/cmd/clawdex/main_test.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -12,7 +12,12 @@ func TestRun(t *testing.T) {
 	var out, errOut bytes.Buffer
 	cfg := filepath.Join(t.TempDir(), "config.toml")
 	code := run([]string{"--config", cfg, "config"}, &out, &errOut)
-	if code != 0 || strings.Contains(out.String(), "steipete") {
+	var payload struct {
+		Git struct {
+			Remote string `json:"remote"`
+		} `json:"git"`
+	}
+	if code != 0 || json.Unmarshal(out.Bytes(), &payload) != nil || payload.Git.Remote != "" {
 		t.Fatalf("code=%d out=%s err=%s", code, out.String(), errOut.String())
 	}
 	code = run([]string{"--bogus"}, &out, &errOut)

--- a/docs/config.md
+++ b/docs/config.md
@@ -49,6 +49,10 @@ clawdex config set git.branch main
 clawdex config set google.default_account you@gmail.com
 ```
 
+`clawdex init DIR --remote URL` also writes `git.remote` during initial
+setup. Without `--remote`, contacts stay local-only until a remote is
+configured.
+
 `clawdex config set` writes the user-level config file. `--dry-run`
 echoes the resolved config without writing.
 

--- a/docs/git-sync.md
+++ b/docs/git-sync.md
@@ -4,7 +4,8 @@ Your contacts data repo is just a Git repo. Clawdex doesn't run a sync
 daemon, doesn't talk to a clawdex.sh server, and doesn't store anything
 about you remotely. Backup and multi-device sync are 100% Git.
 
-The default suggested remote is a *private* GitHub repo:
+Contacts stay local by default. For backup and multi-device sync, use a
+*private* GitHub repo:
 
 ```text
 https://github.com/<you>/backup-clawdex.git

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,14 +15,15 @@ Other paths (Go install, source build, release archives) are documented on
 ## 2. Pick a place for your contacts
 
 The CLI lives in this repo. Your contacts live in **a separate, private
-markdown repo** that you own. The default suggested remote is:
+markdown repo** that you own. Contacts stay local by default. If you want Git
+backup or multi-device sync, use a private remote such as:
 
 ```text
 https://github.com/<you>/backup-clawdex.git
 ```
 
-Create that empty private repo on GitHub first — it's where your data will
-back up to.
+Create that empty private repo on GitHub first if you want backup — it's where
+your data will back up to.
 
 ## 3. Initialize a contacts data repo
 
@@ -30,6 +31,12 @@ back up to.
 clawdex init ~/.clawdex/contacts
 clawdex config set repo_path ~/.clawdex/contacts
 clawdex config set git.remote https://github.com/<you>/backup-clawdex.git
+```
+
+You can also set the backup remote during initialization:
+
+```bash
+clawdex init ~/.clawdex/contacts --remote https://github.com/<you>/backup-clawdex.git
 ```
 
 `init` writes:

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -257,6 +257,16 @@ func TestExecuteGitStatusAndDryRun(t *testing.T) {
 	if !strings.Contains(out.String(), "No commits yet") {
 		t.Fatalf("git status = %s", out.String())
 	}
+	for _, args := range [][]string{
+		{"--config", cfg, "git", "push"},
+		{"--config", cfg, "git", "pull"},
+	} {
+		out.Reset()
+		errOut.Reset()
+		if err := Execute(args, &out, &errOut); err == nil || !strings.Contains(err.Error(), "git remote is not configured") {
+			t.Fatalf("%v: err=%v stdout=%s stderr=%s", args, err, out.String(), errOut.String())
+		}
+	}
 }
 
 func TestExecuteImportDiscrawlErrors(t *testing.T) {
@@ -424,6 +434,40 @@ func TestExecuteGitPushPullWithLocalRemote(t *testing.T) {
 		{"--config", cfg, "init", data, "--remote", remote},
 		{"--config", cfg, "person", "add", "Ada Remote"},
 		{"--config", cfg, "git", "commit", "-m", "test: remote"},
+		{"--config", cfg, "git", "push"},
+		{"--config", cfg, "git", "pull"},
+	} {
+		out.Reset()
+		errOut.Reset()
+		if err := Execute(args, &out, &errOut); err != nil {
+			t.Fatalf("%v: %v stderr=%s stdout=%s", args, err, errOut.String(), out.String())
+		}
+	}
+}
+
+func TestExecuteGitPushPullWithExistingOrigin(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.toml")
+	data := filepath.Join(dir, "contacts")
+	remote := filepath.Join(dir, "remote.git")
+	if err := os.Mkdir(remote, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runShell(t, remote, "git", "init", "--bare")
+	var out, errOut bytes.Buffer
+	for _, args := range [][]string{
+		{"--config", cfg, "init", data, "--remote", ""},
+		{"--config", cfg, "person", "add", "Ada Origin"},
+		{"--config", cfg, "git", "commit", "-m", "test: origin"},
+	} {
+		out.Reset()
+		errOut.Reset()
+		if err := Execute(args, &out, &errOut); err != nil {
+			t.Fatalf("%v: %v stderr=%s stdout=%s", args, err, errOut.String(), out.String())
+		}
+	}
+	runShell(t, data, "git", "remote", "add", "origin", remote)
+	for _, args := range [][]string{
 		{"--config", cfg, "git", "push"},
 		{"--config", cfg, "git", "pull"},
 	} {

--- a/internal/repo/config.go
+++ b/internal/repo/config.go
@@ -12,7 +12,7 @@ import (
 const (
 	DefaultConfigEnv = "CLAWDEX_CONFIG"
 	RepoEnv          = "CLAWDEX_REPO"
-	DefaultRemote    = "https://github.com/steipete/backup-clawdex.git"
+	DefaultRemote    = ""
 )
 
 type Config struct {

--- a/internal/repo/git.go
+++ b/internal/repo/git.go
@@ -2,20 +2,43 @@ package repo
 
 import (
 	"context"
+	"errors"
+	"os/exec"
+	"strings"
 
 	"github.com/openclaw/crawlkit/mirror"
 )
+
+var ErrRemoteNotConfigured = errors.New("git remote is not configured; run clawdex config set git.remote URL or clawdex init DIR --remote URL")
 
 func (r Repo) MirrorOptions() mirror.Options {
 	return mirror.Options{RepoPath: r.Path, Remote: r.Config.Git.Remote, Branch: r.Config.Git.Branch}
 }
 
 func (r Repo) Pull(ctx context.Context) error {
+	if err := r.requireRemote(ctx); err != nil {
+		return err
+	}
 	return mirror.PullCurrent(ctx, r.MirrorOptions())
 }
 
 func (r Repo) Push(ctx context.Context) error {
+	if err := r.requireRemote(ctx); err != nil {
+		return err
+	}
 	return mirror.Push(ctx, r.MirrorOptions())
+}
+
+func (r Repo) requireRemote(ctx context.Context) error {
+	if strings.TrimSpace(r.Config.Git.Remote) != "" {
+		return nil
+	}
+	// #nosec G204 -- git is fixed and repo path is passed as a plain argument.
+	cmd := exec.CommandContext(ctx, "git", "-C", r.Path, "remote", "get-url", "origin")
+	if err := cmd.Run(); err == nil {
+		return nil
+	}
+	return ErrRemoteNotConfigured
 }
 
 func (r Repo) Commit(ctx context.Context, message string) (bool, error) {


### PR DESCRIPTION
## Summary

- stop defaulting new clawdex configs to Peter's backup repository
- keep contacts local unless the user explicitly configures a private Git remote
- update README/docs language to describe private backup as optional

## Why

`clawdex init` currently resolves an omitted remote to `https://github.com/steipete/backup-clawdex.git`. For a personal contacts tool, the safe default should be local-only. Users can still set their own private remote with `clawdex config set git.remote ...` or `clawdex init --remote ...`.

## Validation

- `go test -count=1 ./...`
- `go vet ./...`
- `git diff --check`
- smoke: `go run ./cmd/clawdex --config "$tmp/config.toml" init "$tmp/contacts" --plain` prints an empty `remote:`
