### PR TITLE
build: move Go floor to 1.26.6

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Setup exact Go toolchain
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
           cache: false
 
       - name: Download exact release inventory
@@ -158,7 +158,7 @@ jobs:
       - name: Setup exact Go metadata reader
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
           cache: false
 
       - name: Verify notarized candidate without token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Hardened avatar storage and vCard avatar reads against symlink escapes, and made avatar and vCard file replacement private and atomic.
 - Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.
-- Updated to Go 1.26.5 and CrawlKit 0.13.4 to address reachable Go standard-library vulnerability GO-2026-5856.
+- Updated to Go 1.26.6 and CrawlKit 0.13.4 to resolve Go standard-library vulnerabilities GO-2026-5856, GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
 - Fixed Unicode-safe search snippets, live Discrawl WAL reads, unexpected person-directory errors, and tagged `go install` version reporting.
 - Replaced legacy CI publication with a credential-free, read-only mounted release driver, locally Foundation-signed and notarized Darwin artifacts, protected-default-branch signed-tag-object reproduction, exact embedded-requirement, provenance, signature, online notarization, sealed-snapshot publication, and downstream re-download verification.
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Foundation-signed with the permanent identifier
 `org.openclaw.clawdex`, hardened runtime, secure timestamp, and Apple
 notarization. A protected-default-branch workflow verifies the exact uploaded
 inventory, trusted signed tag object and commit, reproducible non-Darwin payloads, checksums,
-provenance, Darwin build metadata bound to that commit and Go 1.26.5,
+provenance, Darwin build metadata bound to that commit and Go 1.26.6,
 signatures, exact embedded designated requirements, and online notarization
 constraints before publication. After separate VM and approval gates, the
 protected workflow publishes and re-downloads the exact sealed asset snapshot.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -194,7 +194,7 @@ Darwin binaries must have hardened runtime, secure timestamp, identifier
 `org.openclaw.clawdex`, Foundation authority/team, the expected thin
 architecture, exact embedded designated requirement, accepted notary
 submission, embedded clean VCS revision matching the signed tag commit, exact
-Go 1.26.5 build metadata, correct runtime version, and an online
+Go 1.26.6 build metadata, correct runtime version, and an online
 `codesign --verify --strict --check-notarization -R=notarized` result. A
 standalone command-line binary has no stapling container.
 
@@ -249,7 +249,7 @@ leaving a misleading all-skipped green run. The workflow:
    embedded name to equal the requested ref, verifies its signature against
    that protected trust anchor, and binds provenance to both the annotated tag
    object and resulting commit.
-4. Uses exact Go 1.26.5 to rebuild all four Linux and Windows binaries from the
+4. Uses exact Go 1.26.6 to rebuild all four Linux and Windows binaries from the
    trusted tag and byte-compares them with the uploaded payloads.
 5. Seals that exact eight-file snapshot as a workflow artifact;
    both Darwin jobs consume its artifact ID instead of re-downloading mutable
@@ -260,7 +260,7 @@ leaving a misleading all-skipped green run. The workflow:
    provenance, Foundation signature, identifier, exact embedded designated
    requirement, hardened runtime, secure timestamp, exactly one architecture,
    clean embedded VCS revision matching the authenticated commit, exact Go
-   1.26.5 build metadata, online notarization constraint, and `--version` on
+   1.26.6 build metadata, online notarization constraint, and `--version` on
    native Intel and Apple Silicon runners.
 8. After protected-environment approval, authenticates the exact repository,
    tag object, commit, verifier commit, release ID, workflow run, and sealed

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/clawdex
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/alecthomas/kong v1.15.0

--- a/scripts/test-clawdex-release.sh
+++ b/scripts/test-clawdex-release.sh
@@ -62,7 +62,7 @@ grep -F "      release-id: \${{ steps.download.outputs.release-id }}" \
 grep -F "          EXPECTED_RELEASE_ID: \${{ needs.verify-inventory.outputs.release-id }}" \
   "$ROOT/.github/workflows/release-assets.yml" >/dev/null || \
   fail "publisher does not receive the verified draft ID"
-[[ "$(grep -Fc '          go-version: 1.26.5' "$ROOT/.github/workflows/release-assets.yml")" == 2 ]] || \
+[[ "$(grep -Fc '          go-version: 1.26.6' "$ROOT/.github/workflows/release-assets.yml")" == 2 ]] || \
   fail "native verification jobs do not use the exact Go metadata reader"
 [[ "$(grep -Fc 'download-clawdex-release-assets.sh' "$ROOT/.github/workflows/release-assets.yml")" == 1 ]] || \
   fail "workflow must download the mutable release exactly once"
@@ -188,7 +188,7 @@ case "${1:-}" in
     destination=${!#}
     mock_root=$(cd "$(dirname "$0")/.." && pwd)
     mkdir -p "$destination"
-    printf 'module github.com/openclaw/clawdex\n\ngo 1.26.5\n' > "$destination/go.mod"
+    printf 'module github.com/openclaw/clawdex\n\ngo 1.26.6\n' > "$destination/go.mod"
     cp "$mock_root/release-changelog.md" "$destination/CHANGELOG.md"
     ;;
   rev-parse)
@@ -251,7 +251,7 @@ EOF
 cat > "$FAKE_BIN/go" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == env && "${2:-}" == GOVERSION ]]; then
-  echo go1.26.5
+  echo go1.26.6
   exit 0
 fi
 if [[ "${1:-}" == version && "${2:-}" == -m && "${3:-}" == -json ]]; then
@@ -260,7 +260,7 @@ if [[ "${1:-}" == version && "${2:-}" == -m && "${3:-}" == -json ]]; then
     *) goarch=arm64 ;;
   esac
   jq -n \
-    --arg go_version "${MOCK_BUILD_GO_VERSION:-go1.26.5}" \
+    --arg go_version "${MOCK_BUILD_GO_VERSION:-go1.26.6}" \
     --arg path "${MOCK_BUILD_PATH:-github.com/openclaw/clawdex/cmd/clawdex}" \
     --arg module "${MOCK_BUILD_MODULE:-github.com/openclaw/clawdex}" \
     --arg commit "${MOCK_BUILD_COMMIT:-0123456789abcdef0123456789abcdef01234567}" \
@@ -541,12 +541,12 @@ for name in "${expected_names[@]}"; do
   [[ -f "$RELEASE_DIR/$name" ]] || fail "missing release asset: $name"
 done
 [[ "$(find "$RELEASE_DIR" -type f | wc -l | tr -d ' ')" == "${#expected_names[@]}" ]] || fail "unexpected release inventory"
-jq -e '.schema_version == 3 and .tag == "v0.1.1" and .tag_object == "0123456789abcdef0123456789abcdef01234567" and .go_version == "go1.26.5" and .driver_commit == "0123456789abcdef0123456789abcdef01234567" and (.release_notes | length > 0) and (.artifacts | length == 6) and (.darwin | length == 2)' \
+jq -e '.schema_version == 3 and .tag == "v0.1.1" and .tag_object == "0123456789abcdef0123456789abcdef01234567" and .go_version == "go1.26.6" and .driver_commit == "0123456789abcdef0123456789abcdef01234567" and (.release_notes | length > 0) and (.artifacts | length == 6) and (.darwin | length == 2)' \
   "$RELEASE_DIR/provenance.json" >/dev/null
 
 TRUSTED_SOURCE="$WORK_DIR/trusted-source"
 mkdir -p "$TRUSTED_SOURCE"
-printf 'module github.com/openclaw/clawdex\n\ngo 1.26.5\n' > "$TRUSTED_SOURCE/go.mod"
+printf 'module github.com/openclaw/clawdex\n\ngo 1.26.6\n' > "$TRUSTED_SOURCE/go.mod"
 cp "$WORK_DIR/release-changelog.md" "$TRUSTED_SOURCE/CHANGELOG.md"
 
 if MOCK_GIT_VERIFY_TAG=fail EXPECTED_COMMIT=0123456789abcdef0123456789abcdef01234567 \

--- a/scripts/verify-clawdex-release.sh
+++ b/scripts/verify-clawdex-release.sh
@@ -111,7 +111,7 @@ jq -se \
      (.tag_object | test("^[0-9a-f]{40}$")) and
      (.commit | test("^[0-9a-f]{40}$")) and
      (.driver_commit | test("^[0-9a-f]{40}$")) and
-     .go_version == "go1.26.5" and
+     .go_version == "go1.26.6" and
      (.source_date_epoch | type == "number" and floor == . and . > 0) and
      (.release_notes | type == "array" and length > 0) and
      all(.release_notes[];
@@ -299,8 +299,8 @@ if [[ "$MODE" == --non-darwin ]]; then
   }
   required_go="go$(awk '/^go / { print $2; exit }' "$SOURCE_DIR/go.mod")"
   actual_go=$(GOTOOLCHAIN=local GOENV=off go env GOVERSION)
-  [[ "$required_go" == go1.26.5 && "$actual_go" == "$required_go" ]] || {
-    echo "non-Darwin reproduction requires go1.26.5, found $actual_go for $required_go source" >&2
+  [[ "$required_go" == go1.26.6 && "$actual_go" == "$required_go" ]] || {
+    echo "non-Darwin reproduction requires go1.26.6, found $actual_go for $required_go source" >&2
     exit 1
   }
 
@@ -374,7 +374,7 @@ jq -e \
   --arg commit "$EXPECTED_COMMIT" \
   --arg goarch "$goarch" \
   'def setting($key): [.Settings[] | select(.Key == $key) | .Value];
-   .GoVersion == "go1.26.5" and
+   .GoVersion == "go1.26.6" and
    .Path == "github.com/openclaw/clawdex/cmd/clawdex" and
    .Main.Path == "github.com/openclaw/clawdex" and
    setting("vcs") == ["git"] and


### PR DESCRIPTION
Raises the minimum Go toolchain and every authenticated release-provenance assertion to 1.26.6, including release workflows, reproduction guards, test fixtures, and active release documentation. This clears GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218. Verified with the exact Go 1.26.6 build and test suite, govulncheck, the full release-contract test, and a live CLI version/help smoke.