### PR TITLE
fix(google): cap contacts list pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.1 - Unreleased
 
+- Capped Google Contacts import pagination at 50 pages and reject a repeated nextPageToken so a stuck gog pager cannot hang `clawdex import google`.
 - Hardened avatar storage and vCard avatar reads against symlink escapes, and made avatar and vCard file replacement private and atomic.
 - Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.
 - Updated to Go 1.26.6 and CrawlKit 0.13.4 to resolve Go standard-library vulnerabilities GO-2026-5856, GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 0.1.1 - Unreleased
 
-- Capped Google Contacts import pagination at 50 pages and reject a repeated nextPageToken so a stuck gog pager cannot hang `clawdex import google`.
 - Hardened avatar storage and vCard avatar reads against symlink escapes, and made avatar and vCard file replacement private and atomic.
 - Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.
 - Updated to Go 1.26.6 and CrawlKit 0.13.4 to resolve Go standard-library vulnerabilities GO-2026-5856, GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.

--- a/internal/google/gog.go
+++ b/internal/google/gog.go
@@ -50,6 +50,7 @@ func (g GogAdapter) ListContactsWithOptions(ctx context.Context, account string,
 	}
 	var out []model.SourceContact
 	page := ""
+	seenPages := make(map[string]struct{})
 	for pages := 0; pages < maxContactsListPages; pages++ {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -82,8 +83,11 @@ func (g GogAdapter) ListContactsWithOptions(ctx context.Context, account string,
 			}
 			return out, nil
 		}
-		if nextPage == page {
+		if _, seen := seenPages[nextPage]; seen || nextPage == page {
 			return nil, fmt.Errorf("gog contacts list: repeated nextPageToken %q", nextPage)
+		}
+		if page != "" {
+			seenPages[page] = struct{}{}
 		}
 		page = nextPage
 	}

--- a/internal/google/gog.go
+++ b/internal/google/gog.go
@@ -20,7 +20,11 @@ const (
 	maxAvatarConcurrency     = 8
 	maxAvatarBytes           = 10 << 20
 	avatarLookupTimeout      = 20 * time.Second
-	maxContactsListPages     = 50
+	// Safety ceiling for a nextPageToken that keeps changing. Google does
+	// not publish a contacts page maximum; 500 pages at --max 1000 is
+	// 500_000 contacts, well above a normal account, and still stops a
+	// unique-token hang. A listing that ends before this bound succeeds.
+	maxContactsListPages = 500
 )
 
 type Options struct {

--- a/internal/google/gog.go
+++ b/internal/google/gog.go
@@ -20,6 +20,7 @@ const (
 	maxAvatarConcurrency     = 8
 	maxAvatarBytes           = 10 << 20
 	avatarLookupTimeout      = 20 * time.Second
+	maxContactsListPages     = 50
 )
 
 type Options struct {
@@ -45,7 +46,10 @@ func (g GogAdapter) ListContactsWithOptions(ctx context.Context, account string,
 	}
 	var out []model.SourceContact
 	page := ""
-	for {
+	for pages := 0; pages < maxContactsListPages; pages++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		args := []string{"--no-input", "contacts", "list", "--json", "--max", "1000"}
 		if page != "" {
 			args = append(args, "--page", page)
@@ -74,8 +78,12 @@ func (g GogAdapter) ListContactsWithOptions(ctx context.Context, account string,
 			}
 			return out, nil
 		}
+		if nextPage == page {
+			return nil, fmt.Errorf("gog contacts list: repeated nextPageToken %q", nextPage)
+		}
 		page = nextPage
 	}
+	return nil, fmt.Errorf("gog contacts list: exceeded %d pages", maxContactsListPages)
 }
 
 func (o Options) avatarConcurrency() int {

--- a/internal/google/gog.go
+++ b/internal/google/gog.go
@@ -50,7 +50,7 @@ func (g GogAdapter) ListContactsWithOptions(ctx context.Context, account string,
 	}
 	var out []model.SourceContact
 	page := ""
-	seenPages := make(map[string]struct{})
+	seenPageTokens := make(map[string]struct{})
 	for pages := 0; pages < maxContactsListPages; pages++ {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -83,12 +83,10 @@ func (g GogAdapter) ListContactsWithOptions(ctx context.Context, account string,
 			}
 			return out, nil
 		}
-		if _, seen := seenPages[nextPage]; seen || nextPage == page {
+		if _, seen := seenPageTokens[nextPage]; seen {
 			return nil, fmt.Errorf("gog contacts list: repeated nextPageToken %q", nextPage)
 		}
-		if page != "" {
-			seenPages[page] = struct{}{}
-		}
+		seenPageTokens[nextPage] = struct{}{}
 		page = nextPage
 	}
 	return nil, fmt.Errorf("gog contacts list: exceeded %d pages", maxContactsListPages)

--- a/internal/google/gog_test.go
+++ b/internal/google/gog_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/openclaw/clawdex/internal/model"
 )
@@ -59,6 +60,58 @@ func TestGogAdapterListContactsUsesNoInput(t *testing.T) {
 	}
 	if !strings.Contains(string(args), "--page") {
 		t.Fatalf("missing page args = %s", args)
+	}
+}
+
+func TestGogAdapterListContactsRejectsRepeatedPageToken(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "gog")
+	if runtime.GOOS == "windows" {
+		bin += ".bat"
+	}
+	count := filepath.Join(dir, "count")
+	script := "#!/bin/sh\necho x >> \"" + count + "\"\nprintf '%s\\n' '{\"contacts\":[{\"resourceName\":\"people/c1\",\"name\":\"Ada\"}],\"nextPageToken\":\"same\"}'\n"
+	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	_, err := (GogAdapter{Binary: bin}).ListContacts(ctx, "ada@example.com")
+	if err == nil || !strings.Contains(err.Error(), `repeated nextPageToken "same"`) {
+		t.Fatalf("err = %v", err)
+	}
+	got, readErr := os.ReadFile(count)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if n := strings.Count(string(got), "x"); n != 2 {
+		t.Fatalf("invocations = %d want 2", n)
+	}
+}
+
+func TestGogAdapterListContactsCapsIncrementingPageTokens(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "gog")
+	if runtime.GOOS == "windows" {
+		bin += ".bat"
+	}
+	count := filepath.Join(dir, "count")
+	script := "#!/bin/sh\nif [ -f \"" + count + "\" ]; then n=$(cat \"" + count + "\"); else n=0; fi\nn=$((n+1))\nprintf '%s\\n' \"$n\" > \"" + count + "\"\nprintf '%s\\n' \"{\\\"contacts\\\":[{\\\"resourceName\\\":\\\"people/c$n\\\",\\\"name\\\":\\\"Ada$n\\\"}],\\\"nextPageToken\\\":\\\"page-$n\\\"}\"\n"
+	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	_, err := (GogAdapter{Binary: bin}).ListContacts(ctx, "ada@example.com")
+	if err == nil || !strings.Contains(err.Error(), "exceeded 50 pages") {
+		t.Fatalf("err = %v", err)
+	}
+	got, readErr := os.ReadFile(count)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if n := strings.TrimSpace(string(got)); n != "50" {
+		t.Fatalf("invocations = %q want 50", n)
 	}
 }
 

--- a/internal/google/gog_test.go
+++ b/internal/google/gog_test.go
@@ -100,18 +100,40 @@ func TestGogAdapterListContactsCapsIncrementingPageTokens(t *testing.T) {
 	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 	defer cancel()
 	_, err := (GogAdapter{Binary: bin}).ListContacts(ctx, "ada@example.com")
-	if err == nil || !strings.Contains(err.Error(), "exceeded 50 pages") {
+	if err == nil || !strings.Contains(err.Error(), "exceeded 500 pages") {
 		t.Fatalf("err = %v", err)
 	}
 	got, readErr := os.ReadFile(count)
 	if readErr != nil {
 		t.Fatal(readErr)
 	}
-	if n := strings.TrimSpace(string(got)); n != "50" {
-		t.Fatalf("invocations = %q want 50", n)
+	if n := strings.TrimSpace(string(got)); n != "500" {
+		t.Fatalf("invocations = %q want 500", n)
+	}
+}
+
+func TestGogAdapterListContactsCompletesAfterFiftyPages(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "gog")
+	if runtime.GOOS == "windows" {
+		bin += ".bat"
+	}
+	count := filepath.Join(dir, "count")
+	script := "#!/bin/sh\nif [ -f \"" + count + "\" ]; then n=$(cat \"" + count + "\"); else n=0; fi\nn=$((n+1))\nprintf '%s\\n' \"$n\" > \"" + count + "\"\nif [ \"$n\" -ge 51 ]; then printf '%s\\n' \"{\\\"contacts\\\":[{\\\"resourceName\\\":\\\"people/c$n\\\",\\\"name\\\":\\\"Ada$n\\\"}]}\"; else printf '%s\\n' \"{\\\"contacts\\\":[{\\\"resourceName\\\":\\\"people/c$n\\\",\\\"name\\\":\\\"Ada$n\\\"}],\\\"nextPageToken\\\":\\\"page-$n\\\"}\"; fi\n"
+	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	contacts, err := (GogAdapter{Binary: bin}).ListContacts(ctx, "ada@example.com")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(contacts) != 51 {
+		t.Fatalf("contacts = %d want 51", len(contacts))
 	}
 }
 

--- a/internal/google/gog_test.go
+++ b/internal/google/gog_test.go
@@ -89,6 +89,32 @@ func TestGogAdapterListContactsRejectsRepeatedPageToken(t *testing.T) {
 	}
 }
 
+func TestGogAdapterListContactsRejectsAlternatingPageTokens(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "gog")
+	if runtime.GOOS == "windows" {
+		bin += ".bat"
+	}
+	count := filepath.Join(dir, "count")
+	script := "#!/bin/sh\necho x >> \"" + count + "\"\nn=$(wc -l < \"" + count + "\")\nif [ $((n % 2)) -eq 1 ]; then tok=A; else tok=B; fi\nprintf '%s\\n' \"{\\\"contacts\\\":[{\\\"resourceName\\\":\\\"people/c$n\\\",\\\"name\\\":\\\"Ada$n\\\"}],\\\"nextPageToken\\\":\\\"$tok\\\"}\"\n"
+	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	_, err := (GogAdapter{Binary: bin}).ListContacts(ctx, "ada@example.com")
+	if err == nil || !strings.Contains(err.Error(), `repeated nextPageToken "A"`) {
+		t.Fatalf("err = %v", err)
+	}
+	got, readErr := os.ReadFile(count)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if n := strings.Count(string(got), "x"); n != 3 {
+		t.Fatalf("invocations = %d want 3", n)
+	}
+}
+
 func TestGogAdapterListContactsCapsIncrementingPageTokens(t *testing.T) {
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "gog")


### PR DESCRIPTION
## What Problem This Solves

`clawdex import google` walks `gog contacts list` by following `nextPageToken` with no page cap and no cycle check. If `gog` or the People API keeps returning the same token, or a fresh token on every page, the import loops until the process is killed. The public command never returns.

This is the same hang class as notcrawl#98 and babelfish#17: a pager that never empties `nextPageToken`.

## Evidence

Public command against a local `gog` stand-in on PATH (same argv as production: `gog --no-input contacts list --json --max 1000`). Built binary: `/tmp/clawdex-pagecap` from this branch.

A sticky token still fails closed on the second page:

```console
$ clawdex import google --account ada@example.com --dry-run
gog contacts list: repeated nextPageToken "same"
exit=1 elapsed=0.037s calls=2
```

A finite two-page listing still imports Ada then Grace.

```console
$ clawdex import google --account ada@example.com --dry-run --json
create Ada people/c1
create Grace people/c2
```

A valid listing that ends on page 51 now succeeds (Claw P1: do not reject a terminating walk past 50). An incrementing hang still stops at 500 pages (`--max 1000` is 500_000 contacts, above a normal account).

```console
$ go test -count=1 -timeout 30s ./internal/google -run 'TestGogAdapterListContacts(UsesNoInput|RejectsRepeatedPageToken|CapsIncrementingPageTokens|CompletesAfterFiftyPages)' -v
--- PASS: TestGogAdapterListContactsUsesNoInput
--- PASS: TestGogAdapterListContactsRejectsRepeatedPageToken
--- PASS: TestGogAdapterListContactsCapsIncrementingPageTokens
--- PASS: TestGogAdapterListContactsCompletesAfterFiftyPages
ok  github.com/openclaw/clawdex/internal/google
```

`CHANGELOG.md` is left to the release process.

## Real behavior proof

- **Behavior or issue addressed:** `clawdex import google` no longer follows `nextPageToken` forever. A repeated token fails on the second page. Unique incrementing tokens fail at page 500. A listing that ends on page 51 still imports.
- **Real environment tested:** macOS (Darwin arm64), Go from the worktree at `/tmp/oc-impl-clawdex-pages`, built `./cmd/clawdex` as `/tmp/clawdex-pagecap`, local contacts repo from `clawdex init`.
- **Exact steps or command run after this patch:** Built `go build -o /tmp/clawdex-pagecap ./cmd/clawdex`. Put `gog` stand-ins on PATH (`repeat`, `increment`, `two-page`, `51-page`). Ran `clawdex --config ... --repo ... import google --account ada@example.com --dry-run` for the hang and two-page cases. Ran `go test -count=1 -race ./internal/google` for the 51-page success and 500-page hang.
- **Evidence after fix:** terminal output from the patched binary and package run:

  ```console
  $ clawdex import google --account ada@example.com --dry-run
  gog contacts list: repeated nextPageToken "same"
  exit=1 elapsed=0.037s calls=2

  $ go test -count=1 ./internal/google -run CompletesAfterFiftyPages
  ok  github.com/openclaw/clawdex/internal/google
  ```

- **Observed result after fix:** A sticky `nextPageToken` of `same` stops after two `gog contacts list` calls. Incrementing `page-N` tokens stop at 500 pages. A 51-page terminating listing returns 51 contacts instead of `exceeded 50 pages`.
- **What was not tested:** A live Google People API account with a real sticky `nextPageToken`. Avatar fetch during a capped walk.

## Summary

- Cap `gog contacts list` pagination at 500 pages.
- Reject a repeated `nextPageToken`.
- Keep a terminating listing that needs more than 50 pages.
- Check `ctx.Err()` at the start of each page so a cancelled import stops between pages.

## Origin

The unbounded `for { nextPageToken }` walk landed in [`fc837601e11b`](https://github.com/openclaw/clawdex/commit/fc837601e11b8e8a2e4dfde3346e74d488456c45) (2026-05-08, Peter Steinberger) in the initial CLI bootstrap. Present for 99 days. Each page already used `CommandContext`; the loop itself had no stop.

## Related

- Sibling: [notcrawl#98](https://github.com/openclaw/notcrawl/pull/98) rejects a repeated MCP `tools/list` cursor.
- Sibling: [babelfish#17](https://github.com/openclaw/babelfish/pull/17) caps MCP `tools/list` at 50 pages and rejects a repeated cursor.

## Verification

- `gofumpt` / `gofmt` clean on `internal/google/gog.go` and `gog_test.go`.
- `go vet ./internal/google`
- `go test -count=1 ./...`
- `go test -count=1 -race ./internal/google`
- `go build -o /tmp/clawdex-pagecap ./cmd/clawdex`
- Live `clawdex import google` against the hang and two-page `gog` stand-ins above.
