### PR TITLE
fix(lint): use integer range in contacts pagination loop

### DIFF
--- a/internal/google/gog.go
+++ b/internal/google/gog.go
@@ -51,7 +51,7 @@ func (g GogAdapter) ListContactsWithOptions(ctx context.Context, account string,
 	var out []model.SourceContact
 	page := ""
 	seenPageTokens := make(map[string]struct{})
-	for pages := 0; pages < maxContactsListPages; pages++ {
+	for range maxContactsListPages {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Main went red on the lint gate right after the robustness-sweep merge; the PR-branch CI does not run this linter. Verified locally: `golangci-lint run` reports 0 issues, build passes.