### PR TITLE
fix(site): harden documentation rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,21 @@ jobs:
         run: |
           "$(go env GOPATH)/bin/gosec" -exclude=G101,G115,G202,G301,G304 ./...
 
+  site:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v6.5.0
+        with:
+          node-version: 24
+
+      - name: Test site tooling
+        run: node --test scripts/*.test.mjs
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.
 - Updated to Go 1.26.6 and CrawlKit 0.13.4 to resolve Go standard-library vulnerabilities GO-2026-5856, GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
 - Fixed Unicode-safe search snippets, live Discrawl WAL reads, unexpected person-directory errors, and tagged `go install` version reporting.
+- Preserved nested entities and markup-like text in generated `llms.txt` metadata.
 - Replaced legacy CI publication with a credential-free, read-only mounted release driver, locally Foundation-signed and notarized Darwin artifacts, protected-default-branch signed-tag-object reproduction, exact embedded-requirement, provenance, signature, online notarization, sealed-snapshot publication, and downstream re-download verification.
 
 ## 0.1.0 - 2026-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 - Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.
 - Updated to Go 1.26.6 and CrawlKit 0.13.4 to resolve Go standard-library vulnerabilities GO-2026-5856, GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
 - Fixed Unicode-safe search snippets, live Discrawl WAL reads, unexpected person-directory errors, and tagged `go install` version reporting.
-- Preserved nested entities and markup-like text in generated `llms.txt` metadata.
-- Added integrity checks for documentation assets and fail-closed Markdown rendering.
 - Replaced legacy CI publication with a credential-free, read-only mounted release driver, locally Foundation-signed and notarized Darwin artifacts, protected-default-branch signed-tag-object reproduction, exact embedded-requirement, provenance, signature, online notarization, sealed-snapshot publication, and downstream re-download verification.
 
 ## 0.1.0 - 2026-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Updated to Go 1.26.6 and CrawlKit 0.13.4 to resolve Go standard-library vulnerabilities GO-2026-5856, GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
 - Fixed Unicode-safe search snippets, live Discrawl WAL reads, unexpected person-directory errors, and tagged `go install` version reporting.
 - Preserved nested entities and markup-like text in generated `llms.txt` metadata.
+- Added integrity checks for documentation assets and fail-closed Markdown rendering.
 - Replaced legacy CI publication with a credential-free, read-only mounted release driver, locally Foundation-signed and notarized Darwin artifacts, protected-default-branch signed-tag-object reproduction, exact embedded-requirement, provenance, signature, online notarization, sealed-snapshot publication, and downstream re-download verification.
 
 ## 0.1.0 - 2026-05-08

--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect x='6' y='14' width='52' height='40' rx='4' fill='%23f5e9c8' stroke='%23231f1c' stroke-width='3'/%3E%3Crect x='6' y='14' width='52' height='8' fill='%23d94e3a'/%3E%3Cline x1='14' y1='32' x2='50' y2='32' stroke='%23231f1c' stroke-width='2'/%3E%3Cline x1='14' y1='40' x2='50' y2='40' stroke='%23231f1c' stroke-width='2'/%3E%3Cline x1='14' y1='48' x2='38' y2='48' stroke='%23231f1c' stroke-width='2'/%3E%3C/svg%3E">
 
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.10.0/styles/atom-one-light.min.css" media="(prefers-color-scheme: light)">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.10.0/styles/atom-one-dark.min.css" media="(prefers-color-scheme: dark)">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.10.0/styles/atom-one-light.min.css" integrity="sha384-w6Ujm1VWa9HYFqGc89oAPn/DWDi2gUamjNrq9DRvEYm2X3ClItg9Y9xs1ViVo5b5" crossorigin="anonymous" media="(prefers-color-scheme: light)">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.10.0/styles/atom-one-dark.min.css" integrity="sha384-oaMLBGEzBOJx3UHwac0cVndtX5fxGQIfnAeFZ35RTgqPcYlbprH9o9PUV/F8Le07" crossorigin="anonymous" media="(prefers-color-scheme: dark)">
 
   <style>
     :root {
@@ -492,11 +492,11 @@
     </footer>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/marked@14.1.3/marked.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/languages/go.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/languages/dockerfile.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.4/dist/purify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked@14.1.3/marked.min.js" integrity="sha384-k8o8HikHweyzW55Wd3wl18ovJj6vHVYNQeQbeSM0fxx+0WiH4TcccOG9uz8Xd2JR" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js" integrity="sha384-GdEWAbCjn+ghjX0gLx7/N1hyTVmPAjdC2OvoAA0RyNcAOhqwtT8qnbCxWle2+uJX" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/languages/go.min.js" integrity="sha384-Mtb4EH3R9NMDME1sPQALOYR8KGqwrXAtmc6XGxDd0XaXB23irPKsuET0JjZt5utI" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/languages/dockerfile.min.js" integrity="sha384-jg4vR4ePpACdBVLAe+31BrI3MW4sfv1AS62HlXRXmQWk2q98yJqKR5VxHzuABw8X" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.4/dist/purify.min.js" integrity="sha384-eEu5CTj3qGvu9PdJuS+YlkNi7d2XxQROAFYOr59zgObtlcux1ae1Il3u7jvdCSWu" crossorigin="anonymous"></script>
 
   <script>
     (function () {
@@ -530,6 +530,20 @@
       const metaSlug = document.getElementById("meta-slug");
       const metaLink = document.getElementById("meta-link");
       const cache = new Map();
+
+      function showMessage(message, error = false) {
+        const paragraph = document.createElement("p");
+        paragraph.className = "placeholder" + (error ? " error" : "");
+        paragraph.textContent = message;
+        article.replaceChildren(paragraph);
+      }
+
+      const missing = ["marked", "hljs", "DOMPurify"].filter(name => !window[name]);
+      if (missing.length) {
+        showMessage("documentation viewer unavailable: missing " + missing.join(", ") + ". Reload to retry.", true);
+        return;
+      }
+      const { marked, hljs, DOMPurify } = window;
 
       // Register short aliases highlight.js doesn't ship by default.
       const ALIASES = { toml: "ini", sh: "bash", shell: "bash", zsh: "bash", txt: "plaintext", text: "plaintext" };
@@ -586,7 +600,7 @@
 
       async function load(slug) {
         setActive(slug);
-        article.innerHTML = '<p class="placeholder">flipping to ' + slug + '…</p>';
+        showMessage("flipping to " + slug + "…");
         let md = cache.get(slug);
         if (!md) {
           try {
@@ -596,12 +610,11 @@
             md = await res.text();
             cache.set(slug, md);
           } catch (err) {
-            article.innerHTML = '<p class="placeholder error">card not found: ' + slug + ' — ' + err.message + '</p>';
+            showMessage("card not found: " + slug + " — " + err.message + ". Reload to retry.", true);
             return;
           }
         }
-        const dirty = marked.parse(md);
-        const clean = window.DOMPurify ? DOMPurify.sanitize(dirty, { ADD_ATTR: ['target'] }) : dirty;
+        const clean = DOMPurify.sanitize(marked.parse(md), { ADD_ATTR: ['target'] });
         article.innerHTML = clean;
 
         const sub = location.hash.split("#")[2];

--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -7,8 +7,8 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const cname = fs.readFileSync(path.join(repoRoot, "CNAME"), "utf8").trim();
 const origin = "https://" + cname;
 const html = fs.readFileSync(path.join(repoRoot, "index.html"), "utf8");
-const title = text(html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1]) || "clawdex";
-const description = attr(html.match(/<meta\s+name=["']description["']\s+content=["']([^"']*)["'][^>]*>/i)?.[1] || "Local-first contact index.");
+const title = normalize(html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1]) || "clawdex";
+const description = normalize(html.match(/<meta\s+name=["']description["']\s+content=["']([^"']*)["'][^>]*>/i)?.[1] || "Local-first contact index.");
 const lines = [
   "# clawdex",
   "",
@@ -26,9 +26,10 @@ const lines = [
 fs.writeFileSync(path.join(repoRoot, "llms.txt"), lines.join("\n"), "utf8");
 console.log("wrote llms.txt");
 
-function text(value) {
-  return attr(value || "").replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim();
-}
-function attr(value) {
-  return String(value || "").replace(/&mdash;/g, "-").replace(/&amp;/g, "&").replace(/&nbsp;/g, " ").trim();
+function normalize(value) {
+  const entities = { "&mdash;": "-", "&amp;": "&", "&nbsp;": " " };
+  return String(value || "")
+    .replace(/&(?:mdash|amp|nbsp);/g, (entity) => entities[entity])
+    .replace(/\s+/g, " ")
+    .trim();
 }

--- a/scripts/generate-llms.test.mjs
+++ b/scripts/generate-llms.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const generator = fs.readFileSync(new URL("./generate-llms.mjs", import.meta.url), "utf8");
+
+function generate({ title, description }) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawdex-llms-"));
+  fs.mkdirSync(path.join(root, "scripts"));
+  fs.writeFileSync(path.join(root, "scripts/generate-llms.mjs"), generator);
+  fs.writeFileSync(path.join(root, "CNAME"), "clawdex.sh\n");
+  fs.writeFileSync(
+    path.join(root, "index.html"),
+    `<title>${title}</title><meta name="description" content="${description}">`,
+  );
+  const result = spawnSync(process.execPath, ["scripts/generate-llms.mjs"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "wrote llms.txt\n");
+  const output = fs.readFileSync(path.join(root, "llms.txt"), "utf8");
+  fs.rmSync(root, { recursive: true, force: true });
+  return output;
+}
+
+const fixtures = [
+  ["current metadata", "Clawdex — local-first contact index", "Personal contact index backed by markdown and private Git.", "Clawdex — local-first contact index", "Personal contact index backed by markdown and private Git."],
+  ["known entities", "Clawdex &mdash; contacts", "Local&nbsp;first &amp; private", "Clawdex - contacts", "Local first & private"],
+  ["nested entities", "Clawdex &amp;mdash; contacts", "Local&amp;nbsp;first", "Clawdex &mdash; contacts", "Local&nbsp;first"],
+  ["markup-like text", "Clawdex <contacts>", "Use <script and <notes> literally", "Clawdex <contacts>", "Use <script and <notes> literally"],
+  ["whitespace", "  Clawdex \n\t contacts  ", "  Local \n\t first  ", "Clawdex contacts", "Local first"],
+];
+
+for (const [name, title, description, expectedTitle, expectedDescription] of fixtures) {
+  test(`generate-llms: ${name}`, () => {
+    const output = generate({ title, description });
+    assert.match(output, new RegExp(`^${escapeRegex(expectedDescription)}$`, "m"));
+    assert.match(output, new RegExp(`^- ${escapeRegex(expectedTitle)}: https://clawdex\\.sh/$`, "m"));
+  });
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/scripts/site-security.test.mjs
+++ b/scripts/site-security.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const html = fs.readFileSync(new URL("../index.html", import.meta.url), "utf8");
+const expected = new Map([
+  ["https://cdn.jsdelivr.net/npm/highlight.js@11.10.0/styles/atom-one-light.min.css", "sha384-w6Ujm1VWa9HYFqGc89oAPn/DWDi2gUamjNrq9DRvEYm2X3ClItg9Y9xs1ViVo5b5"],
+  ["https://cdn.jsdelivr.net/npm/highlight.js@11.10.0/styles/atom-one-dark.min.css", "sha384-oaMLBGEzBOJx3UHwac0cVndtX5fxGQIfnAeFZ35RTgqPcYlbprH9o9PUV/F8Le07"],
+  ["https://cdn.jsdelivr.net/npm/marked@14.1.3/marked.min.js", "sha384-k8o8HikHweyzW55Wd3wl18ovJj6vHVYNQeQbeSM0fxx+0WiH4TcccOG9uz8Xd2JR"],
+  ["https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js", "sha384-GdEWAbCjn+ghjX0gLx7/N1hyTVmPAjdC2OvoAA0RyNcAOhqwtT8qnbCxWle2+uJX"],
+  ["https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/languages/go.min.js", "sha384-Mtb4EH3R9NMDME1sPQALOYR8KGqwrXAtmc6XGxDd0XaXB23irPKsuET0JjZt5utI"],
+  ["https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/languages/dockerfile.min.js", "sha384-jg4vR4ePpACdBVLAe+31BrI3MW4sfv1AS62HlXRXmQWk2q98yJqKR5VxHzuABw8X"],
+  ["https://cdn.jsdelivr.net/npm/dompurify@3.2.4/dist/purify.min.js", "sha384-eEu5CTj3qGvu9PdJuS+YlkNi7d2XxQROAFYOr59zgObtlcux1ae1Il3u7jvdCSWu"],
+]);
+
+function attribute(tag, name) {
+  return tag.match(new RegExp(`\\b${name}="([^"]+)"`))?.[1] || "";
+}
+
+const externalAssets = [
+  ...html.matchAll(/<script\b[^>]*\bsrc="https:\/\/[^"]+"[^>]*>/g),
+  ...html.matchAll(/<link\b(?=[^>]*\brel="stylesheet")(?=[^>]*\bhref="https:\/\/)[^>]*>/g),
+].map((match) => match[0]);
+
+test("pins the exact external asset set", () => {
+  assert.equal(externalAssets.length, expected.size);
+  const actual = new Map(
+    externalAssets.map((tag) => [
+      attribute(tag, tag.startsWith("<script") ? "src" : "href"),
+      attribute(tag, "integrity"),
+    ]),
+  );
+  assert.deepEqual(actual, expected);
+});
+
+test("has no unhashed external scripts or stylesheets", () => {
+  for (const tag of externalAssets) {
+    assert.match(attribute(tag, "integrity"), /^sha384-[A-Za-z0-9+/]+={0,2}$/);
+    assert.equal(attribute(tag, "crossorigin"), "anonymous");
+  }
+});
+
+test("fails closed when renderer dependencies are unavailable", () => {
+  assert.match(html, /const missing = \["marked", "hljs", "DOMPurify"\]/);
+  assert.match(html, /paragraph\.textContent = message/);
+  assert.doesNotMatch(html, /window\.DOMPurify\s*\?/);
+  assert.match(html, /DOMPurify\.sanitize\(marked\.parse\(md\)/);
+  assert.equal([...html.matchAll(/article\.innerHTML/g)].length, 1);
+});


### PR DESCRIPTION
## Summary

- preserve literal metadata while generating `llms.txt`
- pin third-party documentation assets with subresource integrity
- fail closed when the Markdown renderer or sanitizer is unavailable
- add exact site-tooling tests to CI

## CodeQL

- resolves [alerts #1-#5](https://github.com/openclaw/clawdex/security/code-scanning)

## Review follow-up

- removed the two premature changelog entries
- exact-head static proof covers the fail-closed dependency branch, but this repository has no live-browser harness and browser automation was unavailable locally; no end-to-end browser fallback proof is claimed

## Testing

- `node --test scripts/*.test.mjs`
- `actionlint .github/workflows/ci.yml`
- `git diff --check origin/main...HEAD`
