### PR TITLE
fix(index): stop AddNote hang when notes is not a directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.1 - Unreleased
 
+- Fixed `note add` hanging on inaccessible notes paths and corrected duplicate filename suffixes without limiting note counts. Thanks @SebTardif.
 - Hardened avatar storage and vCard avatar reads against symlink escapes, and made avatar and vCard file replacement private and atomic.
 - Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.
 - Updated to Go 1.26.6 and CrawlKit 0.13.4 to resolve Go standard-library vulnerabilities GO-2026-5856, GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -4,8 +4,10 @@ A *note* is a timestamped event attached to a person. Notes capture what
 contacts can't: what you talked about, when, and where it happened.
 
 Notes live under `people/<slug>/notes/`. Each note is a single markdown file
-named `<occurred-at>-<source>.md`, e.g.
-`2026-05-08T09-15-00Z-whatsapp.md`.
+named `<occurred-at>-<kind>.md`, e.g.
+`2026-05-08T09-15-00Z-dm.md`. Notes with the same timestamp and kind get
+numeric suffixes (`-2.md`, `-3.md`, and so on), preserving existing files.
+If the notes path cannot be accessed, `note add` reports the filesystem error.
 
 **Notes are local-only.** They are never written to Apple Contacts, Google
 Contacts, or anywhere else. They are pushed only to your private backup

--- a/internal/google/gog_test.go
+++ b/internal/google/gog_test.go
@@ -3,6 +3,7 @@ package google
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,7 +11,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/openclaw/clawdex/internal/model"
 )
@@ -63,20 +63,33 @@ func TestGogAdapterListContactsUsesNoInput(t *testing.T) {
 	}
 }
 
-func TestGogAdapterListContactsRejectsRepeatedPageToken(t *testing.T) {
+func writePaginationFixture(t *testing.T, maxCalls int, response string) (string, string) {
+	t.Helper()
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "gog")
 	if runtime.GOOS == "windows" {
 		bin += ".bat"
 	}
-	count := filepath.Join(dir, "count")
-	script := "#!/bin/sh\necho x >> \"" + count + "\"\nprintf '%s\\n' '{\"contacts\":[{\"resourceName\":\"people/c1\",\"name\":\"Ada\"}],\"nextPageToken\":\"same\"}'\n"
+	// Bound buggy pagination by call count, independent of subprocess scheduling.
+	script := fmt.Sprintf(`#!/bin/sh
+if [ -f "$0.count" ]; then read -r n < "$0.count"; else n=0; fi
+n=$((n+1))
+printf '%%s\n' "$n" > "$0.count"
+if [ "$n" -gt %d ]; then
+  printf 'unexpected pagination call: %%s\n' "$n" >&2
+  exit 1
+fi
+%s
+`, maxCalls, response)
 	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
-	defer cancel()
-	_, err := (GogAdapter{Binary: bin}).ListContacts(ctx, "ada@example.com")
+	return bin, bin + ".count"
+}
+
+func TestGogAdapterListContactsRejectsRepeatedPageToken(t *testing.T) {
+	bin, count := writePaginationFixture(t, 2, `printf '%s\n' '{"contacts":[{"resourceName":"people/c1","name":"Ada"}],"nextPageToken":"same"}'`)
+	_, err := (GogAdapter{Binary: bin}).ListContacts(t.Context(), "ada@example.com")
 	if err == nil || !strings.Contains(err.Error(), `repeated nextPageToken "same"`) {
 		t.Fatalf("err = %v", err)
 	}
@@ -84,25 +97,15 @@ func TestGogAdapterListContactsRejectsRepeatedPageToken(t *testing.T) {
 	if readErr != nil {
 		t.Fatal(readErr)
 	}
-	if n := strings.Count(string(got), "x"); n != 2 {
-		t.Fatalf("invocations = %d want 2", n)
+	if n := strings.TrimSpace(string(got)); n != "2" {
+		t.Fatalf("invocations = %q want 2", n)
 	}
 }
 
 func TestGogAdapterListContactsRejectsAlternatingPageTokens(t *testing.T) {
-	dir := t.TempDir()
-	bin := filepath.Join(dir, "gog")
-	if runtime.GOOS == "windows" {
-		bin += ".bat"
-	}
-	count := filepath.Join(dir, "count")
-	script := "#!/bin/sh\necho x >> \"" + count + "\"\nn=$(wc -l < \"" + count + "\")\nif [ $((n % 2)) -eq 1 ]; then tok=A; else tok=B; fi\nprintf '%s\\n' \"{\\\"contacts\\\":[{\\\"resourceName\\\":\\\"people/c$n\\\",\\\"name\\\":\\\"Ada$n\\\"}],\\\"nextPageToken\\\":\\\"$tok\\\"}\"\n"
-	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
-	defer cancel()
-	_, err := (GogAdapter{Binary: bin}).ListContacts(ctx, "ada@example.com")
+	bin, count := writePaginationFixture(t, 3, `if [ $((n % 2)) -eq 1 ]; then tok=A; else tok=B; fi
+printf '%s\n' "{\"contacts\":[{\"resourceName\":\"people/c$n\",\"name\":\"Ada$n\"}],\"nextPageToken\":\"$tok\"}"`)
+	_, err := (GogAdapter{Binary: bin}).ListContacts(t.Context(), "ada@example.com")
 	if err == nil || !strings.Contains(err.Error(), `repeated nextPageToken "A"`) {
 		t.Fatalf("err = %v", err)
 	}
@@ -110,25 +113,14 @@ func TestGogAdapterListContactsRejectsAlternatingPageTokens(t *testing.T) {
 	if readErr != nil {
 		t.Fatal(readErr)
 	}
-	if n := strings.Count(string(got), "x"); n != 3 {
-		t.Fatalf("invocations = %d want 3", n)
+	if n := strings.TrimSpace(string(got)); n != "3" {
+		t.Fatalf("invocations = %q want 3", n)
 	}
 }
 
 func TestGogAdapterListContactsCapsIncrementingPageTokens(t *testing.T) {
-	dir := t.TempDir()
-	bin := filepath.Join(dir, "gog")
-	if runtime.GOOS == "windows" {
-		bin += ".bat"
-	}
-	count := filepath.Join(dir, "count")
-	script := "#!/bin/sh\nif [ -f \"" + count + "\" ]; then n=$(cat \"" + count + "\"); else n=0; fi\nn=$((n+1))\nprintf '%s\\n' \"$n\" > \"" + count + "\"\nprintf '%s\\n' \"{\\\"contacts\\\":[{\\\"resourceName\\\":\\\"people/c$n\\\",\\\"name\\\":\\\"Ada$n\\\"}],\\\"nextPageToken\\\":\\\"page-$n\\\"}\"\n"
-	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
-	defer cancel()
-	_, err := (GogAdapter{Binary: bin}).ListContacts(ctx, "ada@example.com")
+	bin, count := writePaginationFixture(t, 500, `printf '%s\n' "{\"contacts\":[{\"resourceName\":\"people/c$n\",\"name\":\"Ada$n\"}],\"nextPageToken\":\"page-$n\"}"`)
+	_, err := (GogAdapter{Binary: bin}).ListContacts(t.Context(), "ada@example.com")
 	if err == nil || !strings.Contains(err.Error(), "exceeded 500 pages") {
 		t.Fatalf("err = %v", err)
 	}
@@ -142,24 +134,24 @@ func TestGogAdapterListContactsCapsIncrementingPageTokens(t *testing.T) {
 }
 
 func TestGogAdapterListContactsCompletesAfterFiftyPages(t *testing.T) {
-	dir := t.TempDir()
-	bin := filepath.Join(dir, "gog")
-	if runtime.GOOS == "windows" {
-		bin += ".bat"
-	}
-	count := filepath.Join(dir, "count")
-	script := "#!/bin/sh\nif [ -f \"" + count + "\" ]; then n=$(cat \"" + count + "\"); else n=0; fi\nn=$((n+1))\nprintf '%s\\n' \"$n\" > \"" + count + "\"\nif [ \"$n\" -ge 51 ]; then printf '%s\\n' \"{\\\"contacts\\\":[{\\\"resourceName\\\":\\\"people/c$n\\\",\\\"name\\\":\\\"Ada$n\\\"}]}\"; else printf '%s\\n' \"{\\\"contacts\\\":[{\\\"resourceName\\\":\\\"people/c$n\\\",\\\"name\\\":\\\"Ada$n\\\"}],\\\"nextPageToken\\\":\\\"page-$n\\\"}\"; fi\n"
-	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
-	defer cancel()
-	contacts, err := (GogAdapter{Binary: bin}).ListContacts(ctx, "ada@example.com")
+	bin, count := writePaginationFixture(t, 51, `if [ "$n" -ge 51 ]; then
+  printf '%s\n' "{\"contacts\":[{\"resourceName\":\"people/c$n\",\"name\":\"Ada$n\"}]}"
+else
+  printf '%s\n' "{\"contacts\":[{\"resourceName\":\"people/c$n\",\"name\":\"Ada$n\"}],\"nextPageToken\":\"page-$n\"}"
+fi`)
+	contacts, err := (GogAdapter{Binary: bin}).ListContacts(t.Context(), "ada@example.com")
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
 	if len(contacts) != 51 {
 		t.Fatalf("contacts = %d want 51", len(contacts))
+	}
+	got, err := os.ReadFile(count)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.TrimSpace(string(got)); n != "51" {
+		t.Fatalf("invocations = %q want 51", n)
 	}
 }
 

--- a/internal/index/store.go
+++ b/internal/index/store.go
@@ -15,8 +15,6 @@ import (
 	"github.com/openclaw/clawdex/internal/repo"
 )
 
-const maxNotePathAttempts = 1000
-
 type Store struct {
 	Repo repo.Repo
 }
@@ -142,7 +140,7 @@ func (s Store) AddNote(personQuery string, note model.Note) (model.Note, error) 
 func uniqueNotePath(dir, fileName string) (string, error) {
 	ext := filepath.Ext(fileName)
 	stem := strings.TrimSuffix(fileName, ext)
-	for i := range maxNotePathAttempts {
+	for i := 0; ; i++ {
 		candidate := fileName
 		if i > 0 {
 			candidate = fmt.Sprintf("%s-%d%s", stem, i+1, ext)
@@ -156,7 +154,6 @@ func uniqueNotePath(dir, fileName string) (string, error) {
 			return "", err
 		}
 	}
-	return "", fmt.Errorf("could not allocate unique note path under %s after %d attempts", dir, maxNotePathAttempts)
 }
 
 func (s Store) Notes(personQuery string) ([]model.Note, error) {

--- a/internal/index/store.go
+++ b/internal/index/store.go
@@ -15,6 +15,8 @@ import (
 	"github.com/openclaw/clawdex/internal/repo"
 )
 
+const maxNotePathAttempts = 1000
+
 type Store struct {
 	Repo repo.Repo
 }
@@ -126,20 +128,35 @@ func (s Store) AddNote(personQuery string, note model.Note) (model.Note, error) 
 	}
 	note.PersonID = p.ID
 	dir := filepath.Join(filepath.Dir(p.Path), "notes")
-	path := filepath.Join(dir, markdown.NoteFileName(note))
-	for i := 2; ; i++ {
-		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
-			break
-		}
-		ext := filepath.Ext(path)
-		base := strings.TrimSuffix(path, ext)
-		path = fmt.Sprintf("%s-%d%s", base, i, ext)
+	path, err := uniqueNotePath(dir, markdown.NoteFileName(note))
+	if err != nil {
+		return model.Note{}, err
 	}
 	note.Path = path
 	if err := markdown.WriteNote(path, note); err != nil {
 		return model.Note{}, err
 	}
 	return note, nil
+}
+
+func uniqueNotePath(dir, fileName string) (string, error) {
+	ext := filepath.Ext(fileName)
+	stem := strings.TrimSuffix(fileName, ext)
+	for i := range maxNotePathAttempts {
+		candidate := fileName
+		if i > 0 {
+			candidate = fmt.Sprintf("%s-%d%s", stem, i+1, ext)
+		}
+		path := filepath.Join(dir, candidate)
+		_, err := os.Stat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			return path, nil
+		}
+		if err != nil {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("could not allocate unique note path under %s after %d attempts", dir, maxNotePathAttempts)
 }
 
 func (s Store) Notes(personQuery string) ([]model.Note, error) {

--- a/internal/index/store_test.go
+++ b/internal/index/store_test.go
@@ -288,15 +288,15 @@ func TestAddNoteUniqueSuffixUsesOriginalBase(t *testing.T) {
 	}
 }
 
-func TestAddNoteUniqueSuffixCap(t *testing.T) {
+func TestAddNoteUniqueSuffixBeyond1000(t *testing.T) {
 	r := testRepo(t)
 	s := New(r)
-	p, err := s.AddPerson("Ada Cap", nil, nil, nil, time.Now())
+	p, err := s.AddPerson("Ada Many Notes", nil, nil, nil, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
 	now := time.Date(2026, 5, 8, 9, 0, 0, 0, time.UTC)
-	n := markdown.NewNote(p.ID, "note", "manual", "cap", now, now, nil)
+	n := markdown.NewNote(p.ID, "note", "manual", "after 1000", now, now, nil)
 	notesDir := filepath.Join(filepath.Dir(p.Path), "notes")
 	if err := os.MkdirAll(notesDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -304,7 +304,7 @@ func TestAddNoteUniqueSuffixCap(t *testing.T) {
 	base := markdown.NoteFileName(n)
 	ext := filepath.Ext(base)
 	stem := strings.TrimSuffix(base, ext)
-	for i := range maxNotePathAttempts {
+	for i := range 1000 {
 		name := base
 		if i > 0 {
 			name = fmt.Sprintf("%s-%d%s", stem, i+1, ext)
@@ -313,8 +313,33 @@ func TestAddNoteUniqueSuffixCap(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if _, err := s.AddNote("Ada Cap", n); err == nil {
-		t.Fatal("expected unique path cap error")
+	added, err := s.AddNote("Ada Many Notes", n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(added.Path) != "2026-05-08T09-00-00Z-note-1001.md" {
+		t.Fatalf("path = %s", added.Path)
+	}
+	entries, err := os.ReadDir(notesDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1001 {
+		t.Fatalf("note files = %d, want 1001", len(entries))
+	}
+	for _, entry := range entries {
+		path := filepath.Join(notesDir, entry.Name())
+		if path == added.Path {
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil || string(data) != "taken" {
+			t.Fatalf("existing note %s changed: data=%q err=%v", path, data, err)
+		}
+	}
+	written, _, err := markdown.ReadNote(added.Path)
+	if err != nil || strings.TrimSpace(written.Body) != n.Body {
+		t.Fatalf("new note body = %q, err=%v", written.Body, err)
 	}
 }
 

--- a/internal/index/store_test.go
+++ b/internal/index/store_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"fmt"
 	"image"
 	"image/color"
 	"image/png"
@@ -224,6 +225,96 @@ func TestNotesMissingDirAndDuplicateNames(t *testing.T) {
 	}
 	if len(notes) != 2 || notes[0].Body == notes[1].Body {
 		t.Fatalf("notes = %#v", notes)
+	}
+}
+
+func TestAddNoteErrorsWhenNotesIsRegularFile(t *testing.T) {
+	r := testRepo(t)
+	s := New(r)
+	p, err := s.AddPerson("Ada Notes File", []string{"ada-notes-file@example.com"}, nil, nil, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	notesPath := filepath.Join(filepath.Dir(p.Path), "notes")
+	if err := os.WriteFile(notesPath, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	n := markdown.NewNote(p.ID, "note", "manual", "hi", time.Time{}, time.Now(), nil)
+	done := make(chan error, 1)
+	go func() {
+		_, addErr := s.AddNote("ada-notes-file@example.com", n)
+		done <- addErr
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error when notes is a regular file")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("AddNote hung when notes is a regular file")
+	}
+}
+
+func TestAddNoteUniqueSuffixUsesOriginalBase(t *testing.T) {
+	r := testRepo(t)
+	s := New(r)
+	if _, err := s.AddPerson("Ada Suffix", nil, nil, nil, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 5, 8, 9, 0, 0, 0, time.UTC)
+	n := markdown.NewNote("", "note", "manual", "first", now, now, nil)
+	first, err := s.AddNote("Ada Suffix", n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n.Body = "second"
+	second, err := s.AddNote("Ada Suffix", n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n.Body = "third"
+	third, err := s.AddNote("Ada Suffix", n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(first.Path) != "2026-05-08T09-00-00Z-note.md" {
+		t.Fatalf("first path = %s", first.Path)
+	}
+	if filepath.Base(second.Path) != "2026-05-08T09-00-00Z-note-2.md" {
+		t.Fatalf("second path = %s", second.Path)
+	}
+	if filepath.Base(third.Path) != "2026-05-08T09-00-00Z-note-3.md" {
+		t.Fatalf("third path = %s", third.Path)
+	}
+}
+
+func TestAddNoteUniqueSuffixCap(t *testing.T) {
+	r := testRepo(t)
+	s := New(r)
+	p, err := s.AddPerson("Ada Cap", nil, nil, nil, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 5, 8, 9, 0, 0, 0, time.UTC)
+	n := markdown.NewNote(p.ID, "note", "manual", "cap", now, now, nil)
+	notesDir := filepath.Join(filepath.Dir(p.Path), "notes")
+	if err := os.MkdirAll(notesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	base := markdown.NoteFileName(n)
+	ext := filepath.Ext(base)
+	stem := strings.TrimSuffix(base, ext)
+	for i := range maxNotePathAttempts {
+		name := base
+		if i > 0 {
+			name = fmt.Sprintf("%s-%d%s", stem, i+1, ext)
+		}
+		if err := os.WriteFile(filepath.Join(notesDir, name), []byte("taken"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := s.AddNote("Ada Cap", n); err == nil {
+		t.Fatal("expected unique path cap error")
 	}
 }
 


### PR DESCRIPTION
`clawdex note add` could hang indefinitely when a person's `notes` path was a regular file or another filesystem error prevented `Stat`. The filename allocator treated every error except not-found as a collision, and successive collisions produced compound suffixes such as `note-2-3.md`.

Return unexpected filesystem errors immediately and generate numeric suffixes from the original filename. Allocation continues past 1,000 occupied names, preserving existing notes. Regression coverage checks the regular-file error, canonical suffixes, and successful creation of `note-1001.md` without changing existing content. The notes documentation and changelog describe the corrected behavior and credit @SebTardif.

Validation also exposed existing Google pagination test timeouts on a loaded host. Those test fixtures now stop by invocation count instead of tight wall-clock deadlines; production Google import behavior is unchanged.

Live proof with built binaries on macOS arm64 showed the original hang timing out after two seconds; the repaired CLI returned the filesystem error in 0.026 seconds and successfully wrote the 1,001st note with all existing files unchanged. All 15 packages passed with the race detector and 90.4% total coverage. Vet passed, and lint reports no findings in the changed code. [Detailed commands and before/after proof](https://github.com/openclaw/clawdex/pull/10#issuecomment-5474425761).

The contributor's original commit is preserved on the PR branch; the maintainer repair is an additional commit, with co-author credit retained.
