### PR TITLE
fix(avatar): cap manual avatar file reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.1 - Unreleased
 
+- Capped manual avatar reads at 10 MiB while preserving oversized legacy avatar metadata and import protection during Doctor repair. Thanks @SebTardif.
 - Fixed `note add` hanging on inaccessible notes paths and corrected duplicate filename suffixes without limiting note counts. Thanks @SebTardif.
 - Hardened avatar storage and vCard avatar reads against symlink escapes, and made avatar and vCard file replacement private and atomic.
 - Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 0.1.1 - Unreleased
 
-- Capped manual avatar reads at 10 MiB while preserving oversized legacy avatar metadata and import protection during Doctor repair. Thanks @SebTardif.
 - Fixed `note add` hanging on inaccessible notes paths and corrected duplicate filename suffixes without limiting note counts. Thanks @SebTardif.
 - Hardened avatar storage and vCard avatar reads against symlink escapes, and made avatar and vCard file replacement private and atomic.
+- Capped manual avatar reads at 10 MiB while preserving oversized legacy avatar metadata and import protection during Doctor repair. Thanks @SebTardif.
 - Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.
 - Updated to Go 1.26.6 and CrawlKit 0.13.4 to resolve Go standard-library vulnerabilities GO-2026-5856, GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
 - Fixed Unicode-safe search snippets, live Discrawl WAL reads, unexpected person-directory errors, and tagged `go install` version reporting.

--- a/docs/avatars.md
+++ b/docs/avatars.md
@@ -38,7 +38,9 @@ same non-writing destination validation.
 Manual source files must be regular files reached without a symlink leaf or a
 symlink beneath the current directory, home directory, or temporary directory.
 This prevents an apparently local avatar from copying unrelated file contents
-into the contacts repo.
+into the contacts repo. Files larger than 10 MiB are rejected, matching the
+Google import avatar cap, so `clawdex person avatar set` cannot load a huge
+path into memory.
 
 Manual avatars are sticky: subsequent `clawdex import apple` and
 `clawdex import google` runs will **never overwrite a manual avatar**. To

--- a/docs/avatars.md
+++ b/docs/avatars.md
@@ -42,6 +42,11 @@ into the contacts repo. Files larger than 10 MiB are rejected, matching the
 Google import avatar cap, so `clawdex person avatar set` cannot load a huge
 path into memory.
 
+For existing stored avatars above this limit, `doctor --repair` reports the
+size error and leaves the avatar file and metadata untouched. The manual
+avatar remains protected from imports; resize it and set it again explicitly
+to bring it within the inspection limit.
+
 Manual avatars are sticky: subsequent `clawdex import apple` and
 `clawdex import google` runs will **never overwrite a manual avatar**. To
 let imports manage the avatar again, clear it first.

--- a/internal/avatar/avatar.go
+++ b/internal/avatar/avatar.go
@@ -199,7 +199,7 @@ func RepairMetadata(root string, person model.Person, now time.Time) (model.Pers
 }
 
 func inspectRootedFile(root, relative string) (model.AvatarRef, error) {
-	data, err := safefile.ReadFile(root, relative)
+	data, err := safefile.ReadFileMax(root, relative, safefile.MaxReadBytes)
 	if err != nil {
 		return model.AvatarRef{}, err
 	}

--- a/internal/avatar/avatar_test.go
+++ b/internal/avatar/avatar_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/openclaw/clawdex/internal/model"
+	"github.com/openclaw/clawdex/internal/safefile"
 )
 
 func TestSetManualValidateAndRepair(t *testing.T) {
@@ -197,6 +198,24 @@ func TestImportedAvatarRejectsSymlinkEscapes(t *testing.T) {
 	}
 	if _, _, err := RepairMetadata(root, symlinkPerson, time.Now()); err == nil {
 		t.Fatal("expected symlink repair rejection")
+	}
+}
+
+func TestSetManualRejectsOversizeSource(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "huge.bin")
+	if err := os.WriteFile(src, make([]byte, safefile.MaxReadBytes+1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	person := model.Person{ID: "person_1", Name: "Ada", Path: filepath.Join(dir, "people", "ada", "person.md")}
+	if _, err := SetManual(dir, person, src, time.Now()); err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("SetManual oversize err = %v", err)
+	}
+	if _, err := ValidateManual(dir, person, src); err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("ValidateManual oversize err = %v", err)
+	}
+	if _, err := InspectFile(src); err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("InspectFile oversize err = %v", err)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -22,7 +22,42 @@ import (
 
 	"github.com/openclaw/clawdex/internal/contactexport"
 	"github.com/openclaw/clawdex/internal/model"
+	"github.com/openclaw/clawdex/internal/safefile"
 )
+
+func TestDoctorPreservesOversizedManualAvatar(t *testing.T) {
+	cfg, data := testPaths(t)
+	src := filepath.Join(t.TempDir(), "avatar.png")
+	writeCLITestPNG(t, src)
+	for _, args := range [][]string{
+		{"init", data, "--remote", ""},
+		{"person", "add", "Legacy Avatar", "--email", "legacy@example.com"},
+		{"person", "avatar", "set", "legacy@example.com", src},
+	} {
+		if err := Execute(append([]string{"--config", cfg}, args...), &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	personPath := filepath.Join(data, "people", "legacy-avatar", "person.md")
+	avatarPath := filepath.Join(filepath.Dir(personPath), "avatars", "avatar.png")
+	if err := os.Truncate(avatarPath, safefile.MaxReadBytes+1); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotTree(t, data)
+	for _, dryRun := range []bool{true, false} {
+		args := []string{"--config", cfg, "doctor", "--repair"}
+		if dryRun {
+			args = append(args, "--dry-run")
+		}
+		err := Execute(args, &bytes.Buffer{}, &bytes.Buffer{})
+		if dryRun && err != nil || !dryRun && !errors.Is(err, safefile.ErrTooLarge) {
+			t.Fatalf("dry-run=%v repair error=%v", dryRun, err)
+		}
+		if after := snapshotTree(t, data); !reflect.DeepEqual(before, after) {
+			t.Fatalf("doctor changed oversized avatar or metadata: before=%v after=%v", before, after)
+		}
+	}
+}
 
 func TestExecuteEndToEndLocalCommands(t *testing.T) {
 	cfg, data := testPaths(t)

--- a/internal/index/avatar.go
+++ b/internal/index/avatar.go
@@ -1,11 +1,13 @@
 package index
 
 import (
+	"errors"
 	"time"
 
 	"github.com/openclaw/clawdex/internal/avatar"
 	"github.com/openclaw/clawdex/internal/markdown"
 	"github.com/openclaw/clawdex/internal/model"
+	"github.com/openclaw/clawdex/internal/safefile"
 )
 
 func (s Store) SetAvatar(personQuery, imagePath string, now time.Time) (model.Person, error) {
@@ -39,6 +41,9 @@ func (s Store) ClearAvatar(personQuery string, now time.Time) (model.Person, err
 
 func (s Store) RepairAvatarMetadata(person model.Person, now time.Time) (model.Person, bool, error) {
 	p, changed, err := avatar.RepairMetadata(s.Repo.Path, person, now)
+	if errors.Is(err, safefile.ErrTooLarge) {
+		return person, false, err
+	}
 	if err != nil {
 		p = avatar.Clear(person)
 		p.UpdatedAt = now.UTC()

--- a/internal/index/store_test.go
+++ b/internal/index/store_test.go
@@ -1,6 +1,8 @@
 package index
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -16,6 +18,7 @@ import (
 	"github.com/openclaw/clawdex/internal/markdown"
 	"github.com/openclaw/clawdex/internal/model"
 	"github.com/openclaw/clawdex/internal/repo"
+	"github.com/openclaw/clawdex/internal/safefile"
 )
 
 func TestAddNoteAndSearch(t *testing.T) {
@@ -129,6 +132,54 @@ func TestAvatarSetAndImportBackfill(t *testing.T) {
 	}
 	if !changed || p.Avatar.Path != "" {
 		t.Fatalf("missing avatar was not cleared: changed=%v avatar=%#v", changed, p.Avatar)
+	}
+}
+
+func TestRepairAvatarMetadataPreservesOversizedManualAvatar(t *testing.T) {
+	r := testRepo(t)
+	s := New(r)
+	p, err := s.AddPerson("Legacy Avatar", []string{"legacy@example.com"}, nil, nil, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(t.TempDir(), "avatar.png")
+	writeTestPNG(t, src)
+	p, err = s.SetAvatar(p.ID, src, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(filepath.Dir(p.Path), p.Avatar.Path)
+	if err := os.Truncate(path, safefile.MaxReadBytes+1); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(p.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, changed, err := s.RepairAvatarMetadata(p, time.Now())
+	if !errors.Is(err, safefile.ErrTooLarge) || changed || got.Avatar != p.Avatar {
+		t.Fatalf("repair changed legacy avatar: changed=%v avatar=%#v err=%v", changed, got.Avatar, err)
+	}
+	after, err := os.ReadFile(p.Path)
+	if err != nil || !bytes.Equal(before, after) {
+		t.Fatalf("repair changed person metadata: %v", err)
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.ImportContacts("apple", []model.SourceContact{{
+		ExternalID: "legacy-apple", Name: p.Name, Emails: p.Emails,
+		Avatar: &model.SourceAvatar{Data: data},
+	}}, false, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	got, err = s.FindPerson(p.ID)
+	if err != nil || got.Avatar != p.Avatar {
+		t.Fatalf("import replaced manual avatar: %#v err=%v", got.Avatar, err)
+	}
+	if info, err := os.Stat(path); err != nil || info.Size() != safefile.MaxReadBytes+1 {
+		t.Fatalf("legacy avatar bytes replaced: %v %v", info, err)
 	}
 }
 

--- a/internal/safefile/safefile.go
+++ b/internal/safefile/safefile.go
@@ -11,6 +11,12 @@ import (
 	"strings"
 )
 
+// MaxReadBytes is the cap for user-selected ReadPath files (10 MiB).
+const MaxReadBytes int64 = 10 << 20
+
+// ErrTooLarge is returned when a capped read exceeds its byte limit.
+var ErrTooLarge = errors.New("file too large")
+
 // Relative returns target as a path beneath root. It rejects lexical escapes;
 // filesystem accessors below additionally reject symbolic-link components.
 func Relative(root, target string) (string, error) {
@@ -59,6 +65,19 @@ func ExistingPath(root, relative string) (string, error) {
 // component. The platform opener anchors the root and rejects links while the
 // path is resolved, so concurrent parent swaps cannot redirect the read.
 func ReadFile(root, relative string) ([]byte, error) {
+	return readFile(root, relative, 0)
+}
+
+// ReadFileMax is ReadFile with a positive byte ceiling. Oversized files are
+// rejected before the body is copied into memory.
+func ReadFileMax(root, relative string, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		return nil, errors.New("max bytes must be positive")
+	}
+	return readFile(root, relative, maxBytes)
+}
+
+func readFile(root, relative string, maxBytes int64) ([]byte, error) {
 	clean, err := cleanRelative(relative)
 	if err != nil {
 		return nil, err
@@ -75,13 +94,31 @@ func ReadFile(root, relative string) ([]byte, error) {
 	if !info.Mode().IsRegular() {
 		return nil, fmt.Errorf("path is not a regular file: %s", clean)
 	}
-	return io.ReadAll(f)
+	if maxBytes > 0 && info.Size() > maxBytes {
+		return nil, fmt.Errorf("%w: %d bytes (max %d)", ErrTooLarge, info.Size(), maxBytes)
+	}
+	if maxBytes <= 0 {
+		return io.ReadAll(f)
+	}
+	limit := maxBytes + 1
+	if limit <= 0 {
+		return io.ReadAll(f)
+	}
+	data, err := io.ReadAll(io.LimitReader(f, limit))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("%w: exceeds %d bytes", ErrTooLarge, maxBytes)
+	}
+	return data, nil
 }
 
 // ReadPath reads an ordinary user-selected file without following symbolic
 // links beneath a trusted process directory. The current directory, home, and
 // temporary directory are treated as anchors so stable platform aliases such
 // as macOS /var can be resolved once without permitting symlinks below them.
+// Reads stop at MaxReadBytes so a huge user path cannot OOM the process.
 func ReadPath(path string) ([]byte, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
@@ -91,7 +128,7 @@ func ReadPath(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ReadFile(root, relative)
+	return readFile(root, relative, MaxReadBytes)
 }
 
 func readPathRoot(abs string) (string, string, error) {

--- a/internal/safefile/safefile_test.go
+++ b/internal/safefile/safefile_test.go
@@ -37,6 +37,46 @@ func TestReadFileRejectsSymlinkLeafAndParent(t *testing.T) {
 	}
 }
 
+func TestReadPathRejectsOversize(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "huge.bin")
+	if err := os.WriteFile(path, make([]byte, MaxReadBytes+1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	data, err := ReadPath(path)
+	if err == nil || !errors.Is(err, ErrTooLarge) || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("ReadPath oversize data=%d err=%v", len(data), err)
+	}
+
+	exact := filepath.Join(root, "exact.bin")
+	if err := os.WriteFile(exact, make([]byte, MaxReadBytes), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	data, err = ReadPath(exact)
+	if err != nil || int64(len(data)) != MaxReadBytes {
+		t.Fatalf("ReadPath exact data=%d err=%v", len(data), err)
+	}
+}
+
+func TestReadFileMaxRejectsOversize(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "file"), []byte("12345"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := ReadFile(root, "file"); err != nil || string(data) != "12345" {
+		t.Fatalf("uncapped ReadFile data=%q err=%v", data, err)
+	}
+	if _, err := ReadFileMax(root, "file", 4); err == nil || !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("ReadFileMax error = %v", err)
+	}
+	if data, err := ReadFileMax(root, "file", 5); err != nil || string(data) != "12345" {
+		t.Fatalf("exact max data=%q err=%v", data, err)
+	}
+	if _, err := ReadFileMax(root, "file", 0); err == nil {
+		t.Fatal("expected non-positive max error")
+	}
+}
+
 func TestReadPathRejectsSymlinkLeafAndParent(t *testing.T) {
 	root := t.TempDir()
 	realDir := filepath.Join(root, "real")


### PR DESCRIPTION
## What Problem This Solves

`clawdex person avatar set PERSON FILE` reads the source image with
`safefile.ReadPath`, which used unbounded `io.ReadAll`. A multi-gigabyte
file is copied into memory for SHA256 and MIME sniffing before any image
decode. The process can run out of memory. `--dry-run` uses the same read.

Google import already stops avatar downloads at 10 MiB
(`maxAvatarBytes` in `internal/google/gog.go`). Manual set did not.

## Evidence

Built `clawdex` from this branch to `/tmp/clawdex-f004-bin`. Initialized a
fresh contacts repo, added `Proof Person`, then pointed avatar set at a
10485761-byte file (10 MiB plus 1).

Unpatched `ReadPath` loaded the whole file (10485761 bytes, no error).
After the patch the public command fails closed:

```console
$ clawdex person avatar set "Proof Person" huge.bin
file too large: 10485761 bytes (max 10485760)
```

```console
$ clawdex --dry-run person avatar set "Proof Person" huge.bin
file too large: 10485761 bytes (max 10485760)
```

A 69-byte PNG still sets normally (`avatars/avatar.png`, `image/png`, 1x1).

## Real behavior proof

- **Behavior or issue addressed:** Manual avatar set and dry-run no longer read an oversized source into memory. They reject files above 10 MiB, the same cap as Google import avatars.
- **Real environment tested:** macOS Darwin arm64, Go 1.27.0, clawdex built from this branch to `/tmp/clawdex-f004-bin`, isolated `--config` at `/tmp/clawdex-f004-proof/config.toml`.
- **Exact steps or command run after this patch:**

  ```bash
  clawdex --config /tmp/clawdex-f004-proof/config.toml init /tmp/clawdex-f004-proof/contacts --remote ""
  clawdex --config /tmp/clawdex-f004-proof/config.toml person add "Proof Person"
  # write 10485761 zero bytes to huge.bin under the contacts repo
  clawdex --config /tmp/clawdex-f004-proof/config.toml person avatar set "Proof Person" huge.bin
  clawdex --config /tmp/clawdex-f004-proof/config.toml --dry-run person avatar set "Proof Person" huge.bin
  clawdex --config /tmp/clawdex-f004-proof/config.toml person avatar set "Proof Person" tiny.png
  ```

- **Evidence after fix:** terminal output from the patched binary:

  ```console
  $ clawdex person avatar set "Proof Person" huge.bin
  file too large: 10485761 bytes (max 10485760)

  $ clawdex --dry-run person avatar set "Proof Person" huge.bin
  file too large: 10485761 bytes (max 10485760)

  $ clawdex person avatar set "Proof Person" tiny.png
  {
    "path": "avatars/avatar.png",
    "source": "manual",
    "mime": "image/png",
    "width": 1,
    "height": 1
  }
  ```

- **Observed result after fix:** Oversized sources return `file too large` and exit 1. A valid small PNG still writes `avatars/avatar.png`.
- **What was not tested:** Apple Contacts thumbnail import of a source larger than 10 MiB (thumbnails are small). Windows ReadPath.
