### PR TITLE
fix(google): give avatar HTTP client a timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## 0.1.1 - Unreleased
 
-- Added a dedicated 20-second HTTP timeout for Google avatar downloads while preserving earlier caller cancellation. Thanks @SebTardif.
 - Fixed `note add` hanging on inaccessible notes paths and corrected duplicate filename suffixes without limiting note counts. Thanks @SebTardif.
 - Hardened avatar storage and vCard avatar reads against symlink escapes, and made avatar and vCard file replacement private and atomic.
 - Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.
 - Updated to Go 1.26.6 and CrawlKit 0.13.4 to resolve Go standard-library vulnerabilities GO-2026-5856, GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
 - Fixed Unicode-safe search snippets, live Discrawl WAL reads, unexpected person-directory errors, and tagged `go install` version reporting.
+- Added a dedicated 20-second HTTP timeout for Google avatar downloads while preserving earlier caller cancellation. Thanks @SebTardif.
 - Replaced legacy CI publication with a credential-free, read-only mounted release driver, locally Foundation-signed and notarized Darwin artifacts, protected-default-branch signed-tag-object reproduction, exact embedded-requirement, provenance, signature, online notarization, sealed-snapshot publication, and downstream re-download verification.
 
 ## 0.1.0 - 2026-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.1 - Unreleased
 
+- Added a dedicated 20-second HTTP timeout for Google avatar downloads while preserving earlier caller cancellation. Thanks @SebTardif.
 - Fixed `note add` hanging on inaccessible notes paths and corrected duplicate filename suffixes without limiting note counts. Thanks @SebTardif.
 - Hardened avatar storage and vCard avatar reads against symlink escapes, and made avatar and vCard file replacement private and atomic.
 - Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.

--- a/internal/google/gog.go
+++ b/internal/google/gog.go
@@ -27,6 +27,8 @@ const (
 	maxContactsListPages = 500
 )
 
+var avatarHTTPClient = &http.Client{Timeout: avatarLookupTimeout}
+
 type Options struct {
 	IncludeAvatars    bool
 	AvatarConcurrency int
@@ -318,7 +320,7 @@ func fetchAvatarURL(ctx context.Context, url string) (model.SourceAvatar, error)
 	if err != nil {
 		return model.SourceAvatar{}, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := avatarHTTPClient.Do(req)
 	if err != nil {
 		return model.SourceAvatar{}, err
 	}

--- a/internal/google/gog_test.go
+++ b/internal/google/gog_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/openclaw/clawdex/internal/model"
 )
@@ -347,5 +348,50 @@ func TestFetchAvatarURL(t *testing.T) {
 	}
 	if avatar, err := (GogAdapter{}).fetchAvatar(t.Context(), server.URL+"/avatar.png"); err != nil || string(avatar.Data) != "png" {
 		t.Fatalf("default fetchAvatar = %#v err=%v", avatar, err)
+	}
+}
+
+func TestFetchAvatarURLClientTimeout(t *testing.T) {
+	prev := avatarHTTPClient
+	avatarHTTPClient = &http.Client{Timeout: 50 * time.Millisecond}
+	t.Cleanup(func() { avatarHTTPClient = prev })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Error("ResponseWriter does not support hijacking")
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			t.Errorf("hijack: %v", err)
+			return
+		}
+		t.Cleanup(func() { _ = conn.Close() })
+	}))
+	t.Cleanup(server.Close)
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		_, err := fetchAvatarURL(context.Background(), server.URL+"/stall")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected timeout error from stalled avatar fetch")
+		}
+		if !strings.Contains(err.Error(), "Timeout") && !strings.Contains(err.Error(), "deadline") {
+			t.Fatalf("err = %v", err)
+		}
+		elapsed := time.Since(start)
+		if elapsed >= 2*time.Second {
+			t.Fatalf("stalled fetch returned after %v, want client timeout well under 2s: %v", elapsed, err)
+		}
+		t.Logf("stalled fetch returned in %v: %v", elapsed, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("fetchAvatarURL hung for 2s; client timeout did not fire")
 	}
 }


### PR DESCRIPTION
## What Problem This Solves

`clawdex import google --avatars` downloads each contact photo through
`fetchAvatarURL`. That helper used `http.DefaultClient`, which has no
`Timeout`. Production `attachAvatar` already wraps the call in a 20s
`lookupCtx`, so a stalling photo host does not hang forever on the current
call path.

`DefaultClient` can still stall when a caller passes an unbounded context
(tests use `t.Context()`, and `fetchAvatarURL` is the public import
path). The Google adapter should own a client timeout, the same
belt-and-suspenders pattern as sibling HTTP clients.

This change adds a package-level `avatarHTTPClient` with
`Timeout: avatarLookupTimeout` (20s) and uses it for the GET. Request
contexts still apply via `http.NewRequestWithContext`.

## Evidence

Live `go run` against a TCP listener that accepts and never writes HTTP.
A 50ms client returns in 51ms. `http.DefaultClient` with only a 2s request
context waits the full deadline:

```console
$ go run /tmp/clawdex-avatar-stall-proof.go
stall listener 127.0.0.1:65011 (accepts, never writes HTTP)
timed-50ms client elapsed=51ms err=Get "http://127.0.0.1:65011/stall": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
DefaultClient plus 2s ctx elapsed=2.002s err=Get "http://127.0.0.1:65011/stall": context deadline exceeded
```

After the patch, `fetchAvatarURL` uses that timed client. Grep of the
production helper:

```console
$ rg -n 'DefaultClient|avatarHTTPClient' internal/google/gog.go
30:var avatarHTTPClient = &http.Client{Timeout: avatarLookupTimeout}
323:	resp, err := avatarHTTPClient.Do(req)
```

A stalled photo URL through `fetchAvatarURL(context.Background(), ...)`
now returns in 52ms with `Client.Timeout exceeded while awaiting headers`
instead of sitting until an outer 2s bound.

## Real behavior proof

- **Behavior or issue addressed:** Google avatar HTTP GETs use a dedicated client with a 20s Timeout so an unbounded caller context cannot wait forever on a peer that accepts and never responds.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Go 1.27.0, clawdex worktree `/tmp/clawdex-F001` at branch `fix/google-avatar-http-timeout`.
- **Exact steps or command run after this patch:**

  ```bash
  go run /tmp/clawdex-avatar-stall-proof.go
  rg -n 'DefaultClient|avatarHTTPClient' internal/google/gog.go
  go test -count=1 -timeout 15s -run TestFetchAvatarURLClientTimeout -v ./internal/google
  ```

- **Evidence after fix:** terminal output from the patched tree:

  ```console
  $ go run /tmp/clawdex-avatar-stall-proof.go
  stall listener 127.0.0.1:65011 (accepts, never writes HTTP)
  timed-50ms client elapsed=51ms err=Get "http://127.0.0.1:65011/stall": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
  DefaultClient plus 2s ctx elapsed=2.002s err=Get "http://127.0.0.1:65011/stall": context deadline exceeded

  $ rg -n 'DefaultClient|avatarHTTPClient' internal/google/gog.go
  30:var avatarHTTPClient = &http.Client{Timeout: avatarLookupTimeout}
  323:	resp, err := avatarHTTPClient.Do(req)

  $ go test -count=1 -timeout 15s -run TestFetchAvatarURLClientTimeout -v ./internal/google
  === RUN   TestFetchAvatarURLClientTimeout
      gog_test.go:393: stalled fetch returned in 52.127167ms: Get "http://127.0.0.1:65123/stall": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
  --- PASS: TestFetchAvatarURLClientTimeout (0.05s)
  PASS
  ```

- **Observed result after fix:** A stalling photo host no longer depends on the caller to cancel. `avatarHTTPClient` returns `Client.Timeout exceeded while awaiting headers` in about 50ms when the client Timeout is 50ms. Production keeps the 20s `avatarLookupTimeout`. `http.DefaultClient` is gone from `fetchAvatarURL`.
- **What was not tested:** A live `gog contacts raw` call against a real Google account whose photo URL hangs. Redirect-heavy CDN photo URLs.

## Summary

`fetchAvatarURL` now uses `avatarHTTPClient` (`Timeout: 20s`) instead of
`http.DefaultClient`. `http.NewRequestWithContext` is unchanged so caller
deadlines still apply. Success-path coverage in `TestFetchAvatarURL` still
passes through the new client.

Related:
- Same adapter hang stop: https://github.com/openclaw/clawdex/pull/7
- Avatar size cap (open): https://github.com/openclaw/clawdex/pull/11
- Introduced with `e419451` (`feat: fetch Google contact avatars`, 2026-05-08)
- Go `http.Client.Timeout` includes connect, redirects, and body read; `DefaultClient` is zero
