### PR TITLE
fix(vcard): stop fold loop on invalid UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.1 - Unreleased
 
+- Fixed vCard export hanging on long salvaged names containing invalid UTF-8 bytes. Thanks @SebTardif.
 - Updated Kong to 1.16.1, CrawlKit to 0.14.7, x/sys to 0.47.0, and CI checks while preserving the Go 1.26.6 minimum.
 - Fixed `note add` hanging on inaccessible notes paths and corrected duplicate filename suffixes without limiting note counts. Thanks @SebTardif.
 - Hardened avatar storage and vCard avatar reads against symlink escapes, and made avatar and vCard file replacement private and atomic.

--- a/internal/vcard/vcard.go
+++ b/internal/vcard/vcard.go
@@ -185,8 +185,11 @@ func folded(w io.Writer, line string) error {
 	const limit = 75
 	for len(line) > limit {
 		cut := limit
-		for !utf8.ValidString(line[:cut]) {
+		for cut > 0 && !utf8.ValidString(line[:cut]) {
 			cut--
+		}
+		if cut == 0 {
+			cut = 1
 		}
 		if _, err := fmt.Fprint(w, line[:cut]+"\r\n "); err != nil {
 			return err

--- a/internal/vcard/vcard_test.go
+++ b/internal/vcard/vcard_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+	"unicode/utf8"
 
 	"github.com/openclaw/clawdex/internal/model"
 	"github.com/openclaw/clawdex/internal/safefile"
@@ -261,6 +263,75 @@ func TestVCardHelpers(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "\r\n ") {
 		t.Fatalf("not folded: %q", buf.String())
+	}
+}
+
+func TestFoldedInvalidUTF8DoesNotHang(t *testing.T) {
+	line := "\xff" + strings.Repeat("a", 80)
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- folded(&buf, line)
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("folded hung on a line that starts with invalid UTF-8")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "\r\n ") {
+		t.Fatalf("not folded: %q", out)
+	}
+	unfolded := strings.ReplaceAll(strings.TrimSuffix(out, "\r\n"), "\r\n ", "")
+	if unfolded != line {
+		t.Fatalf("unfolded = %q want %q", unfolded, line)
+	}
+}
+
+func TestFoldedUTF8KeepsRuneBoundaries(t *testing.T) {
+	for _, line := range []string{strings.Repeat("é", 50), strings.Repeat("世", 40)} {
+		var buf bytes.Buffer
+		if err := folded(&buf, line); err != nil {
+			t.Fatal(err)
+		}
+		out := buf.String()
+		if !utf8.ValidString(out) {
+			t.Fatalf("folded split a rune: %q", out)
+		}
+		if !strings.Contains(out, "\r\n ") {
+			t.Fatalf("not folded: %q", out)
+		}
+		unfolded := strings.ReplaceAll(strings.TrimSuffix(out, "\r\n"), "\r\n ", "")
+		if unfolded != line {
+			t.Fatalf("unfolded = %q want %q", unfolded, line)
+		}
+	}
+}
+
+func TestWriteLongInvalidUTF8Name(t *testing.T) {
+	var buf bytes.Buffer
+	person := model.Person{
+		ID:   "person_1",
+		Name: "\xff" + strings.Repeat("a", 80),
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- Write(&buf, []model.Person{person})
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Write hung on a long name that starts with invalid UTF-8")
+	}
+	unfolded := strings.ReplaceAll(buf.String(), "\r\n ", "")
+	if !strings.Contains(unfolded, "FN:\xff"+strings.Repeat("a", 80)) {
+		t.Fatalf("missing FN remainder: %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

`clawdex export vcard --all` can hang forever when `People()` salvages a
`person.md` whose display name is longer than 75 bytes and starts with an
invalid UTF-8 byte.

`folded` in `internal/vcard/vcard.go` wraps RFC 6350 lines at 75 octets and
walks `cut` backward until `utf8.ValidString(line[:cut])` so it does not
split a rune. A leading invalid byte makes every nonempty prefix invalid.
`cut` becomes 0, `ValidString("")` is true, the function writes a blank
continuation (`\r\n `) and does not advance `line`, then repeats.

The loop has been in place since the CLI bootstrap
([`fc837601e1`](https://github.com/openclaw/clawdex/commit/fc837601e1),
2026-05-08). Open PRs [#11](https://github.com/openclaw/clawdex/pull/11)
and [#12](https://github.com/openclaw/clawdex/pull/12) cover avatar reads
and Google HTTP timeouts. They do not touch vCard fold.

## Evidence

Built `clawdex` from this branch and from unpatched `origin/main`. Initialized
a contacts repo, wrote `people/bad-name/person.md` with broken YAML so
`People()` salvages, and set `name` to byte `0xff` plus 80 ASCII `a` bytes
(81 bytes, over the 75-octet fold limit). Then ran the public export.

Unpatched binary (same fixture, 1 second deadline):

```console
$ clawdex --config config.toml --repo contacts --plain export vcard --all -o out.vcf
TIMEOUT after 1000ms (export did not return)
```

Patched binary, same fixture and command:

```console
$ clawdex --config config.toml --repo contacts --plain export vcard --all -o out.vcf
exported: 1
out: C:\Users\sebta\AppData\Local\Temp\clawdex-f006-export\out-fixed.vcf
```

Elapsed 29ms. Output is 288 bytes and starts `BEGIN:VCARD` / `FN:` with the
name folded across continuation lines. Export returns instead of spinning.

A standalone `go` program that calls `vcard.Write` with
`Name: "\xff" + 80*'a'` matches that: unfixed fold hits the 400ms deadline;
patched `Write` returns in 0s with 267 bytes and `contains_FN=true`.

## Real behavior proof

- **Behavior or issue addressed:** vCard export no longer hangs when a salvaged person name is longer than 75 bytes and starts with an invalid UTF-8 byte. Fold advances one invalid byte and finishes the address book.
- **Real environment tested:** Windows amd64, Go 1.26.6, clawdex built from this branch to `bin/clawdex.exe`, isolated config under `%TEMP%\clawdex-f006-export` with `auto_repair = false` so `People()` salvages the broken `person.md`.
- **Exact steps or command run after this patch:**

  ```bash
  clawdex --config config.toml init contacts --remote ""
  write people/bad-name/person.md (broken YAML, name = 0xff + 80 a bytes)
  clawdex --config config.toml --repo contacts --plain export vcard --all -o out.vcf
  ```

- **Evidence after fix:** terminal output from the patched binary:

  ```console
  $ clawdex --config config.toml --repo contacts --plain export vcard --all -o out.vcf
  exported: 1
  out: C:\Users\sebta\AppData\Local\Temp\clawdex-f006-export\out-fixed.vcf
  ```

  Same fixture against the unpatched binary never printed a result (killed after 1s). After the patch the command returns in 29ms and writes a 288-byte `.vcf`.

- **Observed result after fix:** Export completes and writes one vCard. The long FN is folded on 75-octet lines. The rest of the book is not aborted.
- **What was not tested:** Google or Apple import of a long invalid-UTF-8 FN (those adapters emit UTF-8). Live Contacts import of the folded `.vcf` on a phone.
