### PR TITLE
fix(apple): stream contact export decode without a size ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed `note add` hanging on inaccessible notes paths and corrected duplicate filename suffixes without limiting note counts. Thanks @SebTardif.
 - Hardened avatar storage and vCard avatar reads against symlink escapes, and made avatar and vCard file replacement private and atomic.
 - Capped manual avatar reads at 10 MiB while preserving oversized legacy avatar metadata and import protection during Doctor repair. Thanks @SebTardif.
+- Streamed Apple contact export decoding without a total size ceiling, preserving large file and macOS imports and the existing 16 MiB NDJSON record limit. Thanks @SebTardif.
 - Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.
 - Updated to Go 1.26.6 and CrawlKit 0.13.4 to resolve Go standard-library vulnerabilities GO-2026-5856, GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
 - Fixed Unicode-safe search snippets, live Discrawl WAL reads, unexpected person-directory errors, and tagged `go install` version reporting.

--- a/docs/imports.md
+++ b/docs/imports.md
@@ -45,6 +45,10 @@ clawdex import apple --input ~/Desktop/contacts.json
 - `--input PATH` reads JSON or NDJSON instead — useful on Linux, in CI,
   when round-tripping a snapshot, or when deterministic permission behavior is
   required.
+- JSON arrays are decoded one contact at a time, and NDJSON is read one record
+  per line with the existing 16 MiB scanner limit. There is no total export-size
+  ceiling. Decoded contacts are retained until import; direct macOS imports also
+  buffer the Swift helper's output before decoding.
 - `--avatars` imports thumbnail bytes. Without it, only structured fields
   are imported.
 

--- a/internal/apple/apple.go
+++ b/internal/apple/apple.go
@@ -2,18 +2,16 @@ package apple
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"strings"
+	"unicode"
 
 	"github.com/openclaw/clawdex/internal/model"
 )
-
-// 64 MiB ceiling for import apple --input. Must exceed the old 16 MiB per-line max.
-const maxAppleExportBytes = 64 << 20
 
 type Contact struct {
 	Identifier string   `json:"identifier"`
@@ -60,16 +58,8 @@ func ReadFile(path string) ([]Contact, error) {
 }
 
 func Decode(r io.Reader) ([]Contact, error) {
-	return decodeWithLimit(r, maxAppleExportBytes)
-}
-
-func decodeWithLimit(r io.Reader, maxBytes int64) ([]Contact, error) {
-	limited := &io.LimitedReader{R: r, N: maxBytes + 1}
-	br := bufio.NewReader(limited)
+	br := bufio.NewReader(r)
 	first, err := peekNonSpace(br)
-	if limited.N == 0 {
-		return nil, errExportTooLarge(maxBytes)
-	}
 	if errors.Is(err, io.EOF) {
 		return nil, nil
 	}
@@ -77,72 +67,64 @@ func decodeWithLimit(r io.Reader, maxBytes int64) ([]Contact, error) {
 		return nil, err
 	}
 
-	dec := json.NewDecoder(br)
 	if first == '[' {
-		var contacts []Contact
-		if err := dec.Decode(&contacts); err != nil {
-			return nil, limitOr(err, limited, maxBytes)
-		}
-		var extra json.RawMessage
-		extraErr := dec.Decode(&extra)
-		if limited.N == 0 {
-			return nil, errExportTooLarge(maxBytes)
-		}
-		if extraErr == nil {
-			return nil, errors.New("invalid data after JSON array")
-		}
-		if !errors.Is(extraErr, io.EOF) {
-			return nil, extraErr
-		}
-		return contacts, nil
+		return decodeArray(br)
 	}
 
 	var contacts []Contact
-	for {
+	scanner := bufio.NewScanner(br)
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
 		var c Contact
-		if err := dec.Decode(&c); err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			return nil, limitOr(err, limited, maxBytes)
+		if err := json.Unmarshal(line, &c); err != nil {
+			return nil, err
 		}
 		contacts = append(contacts, c)
-		if limited.N == 0 {
-			return nil, errExportTooLarge(maxBytes)
-		}
 	}
-	if limited.N == 0 {
-		return nil, errExportTooLarge(maxBytes)
+	return contacts, scanner.Err()
+}
+
+func decodeArray(br *bufio.Reader) ([]Contact, error) {
+	dec := json.NewDecoder(br)
+	if _, err := dec.Token(); err != nil {
+		return nil, err
+	}
+	var contacts []Contact
+	for dec.More() {
+		var c Contact
+		if err := dec.Decode(&c); err != nil {
+			return nil, err
+		}
+		contacts = append(contacts, c)
+	}
+	if _, err := dec.Token(); err != nil {
+		return nil, err
+	}
+	// Include decoder read-ahead when checking for data after the closing bracket.
+	tail := bufio.NewReader(io.MultiReader(dec.Buffered(), br))
+	if _, err := peekNonSpace(tail); !errors.Is(err, io.EOF) {
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("invalid data after JSON array")
 	}
 	return contacts, nil
 }
 
-func peekNonSpace(br *bufio.Reader) (byte, error) {
+func peekNonSpace(br *bufio.Reader) (rune, error) {
 	for {
-		buf, err := br.Peek(1)
+		r, _, err := br.ReadRune()
 		if err != nil {
 			return 0, err
 		}
-		switch buf[0] {
-		case ' ', '\t', '\n', '\r':
-			if _, err := br.ReadByte(); err != nil {
-				return 0, err
-			}
-		default:
-			return buf[0], nil
+		if !unicode.IsSpace(r) {
+			return r, br.UnreadRune()
 		}
 	}
-}
-
-func errExportTooLarge(maxBytes int64) error {
-	return fmt.Errorf("apple export exceeds %d-byte limit", maxBytes)
-}
-
-func limitOr(err error, limited *io.LimitedReader, maxBytes int64) error {
-	if limited.N == 0 {
-		return errExportTooLarge(maxBytes)
-	}
-	return err
 }
 
 func ToSourceContacts(contacts []Contact, includeAvatars bool) []model.SourceContact {

--- a/internal/apple/apple.go
+++ b/internal/apple/apple.go
@@ -3,6 +3,7 @@ package apple
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -69,7 +70,7 @@ func decodeWithLimit(r io.Reader, maxBytes int64) ([]Contact, error) {
 	if limited.N == 0 {
 		return nil, errExportTooLarge(maxBytes)
 	}
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		return nil, nil
 	}
 	if err != nil {
@@ -88,9 +89,9 @@ func decodeWithLimit(r io.Reader, maxBytes int64) ([]Contact, error) {
 			return nil, errExportTooLarge(maxBytes)
 		}
 		if extraErr == nil {
-			return nil, fmt.Errorf("invalid data after JSON array")
+			return nil, errors.New("invalid data after JSON array")
 		}
-		if extraErr != io.EOF {
+		if !errors.Is(extraErr, io.EOF) {
 			return nil, extraErr
 		}
 		return contacts, nil
@@ -100,7 +101,7 @@ func decodeWithLimit(r io.Reader, maxBytes int64) ([]Contact, error) {
 	for {
 		var c Contact
 		if err := dec.Decode(&c); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return nil, limitOr(err, limited, maxBytes)

--- a/internal/apple/apple.go
+++ b/internal/apple/apple.go
@@ -3,12 +3,16 @@ package apple
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/openclaw/clawdex/internal/model"
 )
+
+// 64 MiB ceiling for import apple --input. Must exceed the old 16 MiB per-line max.
+const maxAppleExportBytes = 64 << 20
 
 type Contact struct {
 	Identifier string   `json:"identifier"`
@@ -55,36 +59,89 @@ func ReadFile(path string) ([]Contact, error) {
 }
 
 func Decode(r io.Reader) ([]Contact, error) {
-	raw, err := io.ReadAll(r)
+	return decodeWithLimit(r, maxAppleExportBytes)
+}
+
+func decodeWithLimit(r io.Reader, maxBytes int64) ([]Contact, error) {
+	limited := &io.LimitedReader{R: r, N: maxBytes + 1}
+	br := bufio.NewReader(limited)
+	first, err := peekNonSpace(br)
+	if limited.N == 0 {
+		return nil, errExportTooLarge(maxBytes)
+	}
+	if err == io.EOF {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}
-	trimmed := strings.TrimSpace(string(raw))
-	if trimmed == "" {
-		return nil, nil
-	}
-	if strings.HasPrefix(trimmed, "[") {
+
+	dec := json.NewDecoder(br)
+	if first == '[' {
 		var contacts []Contact
-		if err := json.Unmarshal([]byte(trimmed), &contacts); err != nil {
-			return nil, err
+		if err := dec.Decode(&contacts); err != nil {
+			return nil, limitOr(err, limited, maxBytes)
+		}
+		var extra json.RawMessage
+		extraErr := dec.Decode(&extra)
+		if limited.N == 0 {
+			return nil, errExportTooLarge(maxBytes)
+		}
+		if extraErr == nil {
+			return nil, fmt.Errorf("invalid data after JSON array")
+		}
+		if extraErr != io.EOF {
+			return nil, extraErr
 		}
 		return contacts, nil
 	}
+
 	var contacts []Contact
-	scanner := bufio.NewScanner(strings.NewReader(trimmed))
-	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
+	for {
 		var c Contact
-		if err := json.Unmarshal([]byte(line), &c); err != nil {
-			return nil, err
+		if err := dec.Decode(&c); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, limitOr(err, limited, maxBytes)
 		}
 		contacts = append(contacts, c)
+		if limited.N == 0 {
+			return nil, errExportTooLarge(maxBytes)
+		}
 	}
-	return contacts, scanner.Err()
+	if limited.N == 0 {
+		return nil, errExportTooLarge(maxBytes)
+	}
+	return contacts, nil
+}
+
+func peekNonSpace(br *bufio.Reader) (byte, error) {
+	for {
+		buf, err := br.Peek(1)
+		if err != nil {
+			return 0, err
+		}
+		switch buf[0] {
+		case ' ', '\t', '\n', '\r':
+			if _, err := br.ReadByte(); err != nil {
+				return 0, err
+			}
+		default:
+			return buf[0], nil
+		}
+	}
+}
+
+func errExportTooLarge(maxBytes int64) error {
+	return fmt.Errorf("apple export exceeds %d-byte limit", maxBytes)
+}
+
+func limitOr(err error, limited *io.LimitedReader, maxBytes int64) error {
+	if limited.N == 0 {
+		return errExportTooLarge(maxBytes)
+	}
+	return err
 }
 
 func ToSourceContacts(contacts []Contact, includeAvatars bool) []model.SourceContact {

--- a/internal/apple/apple_test.go
+++ b/internal/apple/apple_test.go
@@ -3,11 +3,34 @@ package apple
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
+
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
+}
+
+type repeatByteReader struct{ b byte }
+
+func (r repeatByteReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = r.b
+	}
+	return len(p), nil
+}
 
 func TestDecodeJSONArrayAndNDJSON(t *testing.T) {
 	for _, input := range []string{
@@ -69,5 +92,125 @@ func TestDecodeLargeAvatarLine(t *testing.T) {
 	}
 	if len(contacts) != 1 || len(contacts[0].AvatarData) != 128*1024 {
 		t.Fatalf("contacts = %#v", contacts)
+	}
+}
+
+func TestDecodeRejectsOversizedExport(t *testing.T) {
+	if maxAppleExportBytes != 64<<20 {
+		t.Fatalf("maxAppleExportBytes = %d, want 64 MiB", maxAppleExportBytes)
+	}
+	contact := `{"identifier":"a1","full_name":"Ada Lovelace","emails":["ada@example.com"]}`
+	array := `[{"identifier":"a1","full_name":"Ada Lovelace","emails":["ada@example.com"]}]`
+	capName := strconv.FormatInt(maxAppleExportBytes, 10)
+	for _, suffix := range []string{contact + "\n", array} {
+		cr := &countingReader{r: io.MultiReader(
+			io.LimitReader(repeatByteReader{b: ' '}, maxAppleExportBytes+1),
+			strings.NewReader(suffix),
+		)}
+		_, err := Decode(cr)
+		if err == nil {
+			t.Fatal("expected oversized export error")
+		}
+		if !strings.Contains(err.Error(), capName) {
+			t.Fatalf("error %q should name the %d-byte cap", err, maxAppleExportBytes)
+		}
+		if cr.n > maxAppleExportBytes+1 {
+			t.Fatalf("read %d bytes; Decode slurped past the cap", cr.n)
+		}
+	}
+
+	ws := &countingReader{r: io.LimitReader(repeatByteReader{b: ' '}, maxAppleExportBytes+1+(1<<20))}
+	_, err := Decode(ws)
+	if err == nil || !strings.Contains(err.Error(), capName) {
+		t.Fatalf("expected whitespace-only over-cap error, got %v", err)
+	}
+	if ws.n > maxAppleExportBytes+1 {
+		t.Fatalf("read %d bytes; Decode slurped past the cap", ws.n)
+	}
+}
+
+func TestDecodeLeadingWhitespaceAndTrailingArrayJunk(t *testing.T) {
+	contacts, err := Decode(strings.NewReader("  \n\t[{\"identifier\":\"a1\",\"full_name\":\"Ada Lovelace\"}]"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(contacts) != 1 || contacts[0].Name() != "Ada Lovelace" {
+		t.Fatalf("contacts = %#v", contacts)
+	}
+	if _, err := Decode(strings.NewReader(`[{"identifier":"a1","full_name":"Ada"}] extra`)); err == nil {
+		t.Fatal("expected trailing data after JSON array to fail")
+	}
+}
+
+func TestDecodeWithLimitAtAndOverCap(t *testing.T) {
+	const limit int64 = 256
+	base := `[{"identifier":"a1","full_name":"Ada Lovelace"}]`
+	if int64(len(base)) > limit {
+		t.Fatal("fixture larger than test limit")
+	}
+	padded := strings.Repeat(" ", int(limit)-len(base)) + base
+	contacts, err := decodeWithLimit(strings.NewReader(padded), limit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(contacts) != 1 || contacts[0].Name() != "Ada Lovelace" {
+		t.Fatalf("contacts = %#v", contacts)
+	}
+
+	_, err = decodeWithLimit(strings.NewReader(" "+padded), limit)
+	if err == nil || !strings.Contains(err.Error(), strconv.FormatInt(limit, 10)) {
+		t.Fatalf("expected %d-byte cap error, got %v", limit, err)
+	}
+
+	ndjson := `{"identifier":"a1","full_name":"Ada Lovelace"}`
+	cr := &countingReader{r: io.MultiReader(
+		io.LimitReader(repeatByteReader{b: ' '}, 4097),
+		strings.NewReader(ndjson+"\n"),
+	)}
+	_, err = decodeWithLimit(cr, 4096)
+	if err == nil || !strings.Contains(err.Error(), "4096") {
+		t.Fatalf("expected 4096-byte cap error, got %v", err)
+	}
+	if cr.n > 4097 {
+		t.Fatalf("read %d bytes; Decode slurped past the cap", cr.n)
+	}
+}
+
+type errReader struct{ err error }
+
+func (e errReader) Read([]byte) (int, error) { return 0, e.err }
+
+func TestDecodeErrorAndLimitBranches(t *testing.T) {
+	if _, err := Decode(errReader{errors.New("boom")}); err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("reader error = %v", err)
+	}
+	if _, err := Decode(strings.NewReader("[")); err == nil {
+		t.Fatal("expected invalid JSON array error")
+	}
+	if _, err := Decode(strings.NewReader(`[{"identifier":"a1"}]{"identifier":"a2"}`)); err == nil {
+		t.Fatal("expected trailing JSON after array to fail")
+	}
+
+	const limit int64 = 64
+	if _, err := decodeWithLimit(strings.NewReader(`[{"identifier":"`+strings.Repeat("x", 200)), limit); err == nil || !strings.Contains(err.Error(), "64") {
+		t.Fatalf("expected truncated array cap error, got %v", err)
+	}
+
+	base := `[{"identifier":"a1","full_name":"Ada"}]`
+	if _, err := decodeWithLimit(strings.NewReader(base+strings.Repeat(" ", 200)), limit); err == nil || !strings.Contains(err.Error(), "64") {
+		t.Fatalf("expected array padding cap error, got %v", err)
+	}
+
+	prefix, suffix := `{"identifier":"`, `"}`
+	need := int(limit) + 1 - len(prefix) - len(suffix)
+	fat := prefix + strings.Repeat("x", need) + suffix
+	if _, err := decodeWithLimit(strings.NewReader(fat), limit); err == nil || !strings.Contains(err.Error(), "64") {
+		t.Fatalf("expected oversized NDJSON object cap error, got %v", err)
+	}
+
+	obj := `{"identifier":"a1"}`
+	padded := obj + strings.Repeat(" ", int(limit)+1-len(obj))
+	if _, err := decodeWithLimit(strings.NewReader(padded), limit); err == nil || !strings.Contains(err.Error(), "64") {
+		t.Fatalf("expected NDJSON whitespace cap error, got %v", err)
 	}
 }

--- a/internal/apple/apple_test.go
+++ b/internal/apple/apple_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -21,15 +20,6 @@ func (c *countingReader) Read(p []byte) (int, error) {
 	n, err := c.r.Read(p)
 	c.n += int64(n)
 	return n, err
-}
-
-type repeatByteReader struct{ b byte }
-
-func (r repeatByteReader) Read(p []byte) (int, error) {
-	for i := range p {
-		p[i] = r.b
-	}
-	return len(p), nil
 }
 
 func TestDecodeJSONArrayAndNDJSON(t *testing.T) {
@@ -95,40 +85,6 @@ func TestDecodeLargeAvatarLine(t *testing.T) {
 	}
 }
 
-func TestDecodeRejectsOversizedExport(t *testing.T) {
-	if maxAppleExportBytes != 64<<20 {
-		t.Fatalf("maxAppleExportBytes = %d, want 64 MiB", maxAppleExportBytes)
-	}
-	contact := `{"identifier":"a1","full_name":"Ada Lovelace","emails":["ada@example.com"]}`
-	array := `[{"identifier":"a1","full_name":"Ada Lovelace","emails":["ada@example.com"]}]`
-	capName := strconv.FormatInt(maxAppleExportBytes, 10)
-	for _, suffix := range []string{contact + "\n", array} {
-		cr := &countingReader{r: io.MultiReader(
-			io.LimitReader(repeatByteReader{b: ' '}, maxAppleExportBytes+1),
-			strings.NewReader(suffix),
-		)}
-		_, err := Decode(cr)
-		if err == nil {
-			t.Fatal("expected oversized export error")
-		}
-		if !strings.Contains(err.Error(), capName) {
-			t.Fatalf("error %q should name the %d-byte cap", err, maxAppleExportBytes)
-		}
-		if cr.n > maxAppleExportBytes+1 {
-			t.Fatalf("read %d bytes; Decode slurped past the cap", cr.n)
-		}
-	}
-
-	ws := &countingReader{r: io.LimitReader(repeatByteReader{b: ' '}, maxAppleExportBytes+1+(1<<20))}
-	_, err := Decode(ws)
-	if err == nil || !strings.Contains(err.Error(), capName) {
-		t.Fatalf("expected whitespace-only over-cap error, got %v", err)
-	}
-	if ws.n > maxAppleExportBytes+1 {
-		t.Fatalf("read %d bytes; Decode slurped past the cap", ws.n)
-	}
-}
-
 func TestDecodeLeadingWhitespaceAndTrailingArrayJunk(t *testing.T) {
 	contacts, err := Decode(strings.NewReader("  \n\t[{\"identifier\":\"a1\",\"full_name\":\"Ada Lovelace\"}]"))
 	if err != nil {
@@ -142,75 +98,20 @@ func TestDecodeLeadingWhitespaceAndTrailingArrayJunk(t *testing.T) {
 	}
 }
 
-func TestDecodeWithLimitAtAndOverCap(t *testing.T) {
-	const limit int64 = 256
-	base := `[{"identifier":"a1","full_name":"Ada Lovelace"}]`
-	if int64(len(base)) > limit {
-		t.Fatal("fixture larger than test limit")
-	}
-	padded := strings.Repeat(" ", int(limit)-len(base)) + base
-	contacts, err := decodeWithLimit(strings.NewReader(padded), limit)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(contacts) != 1 || contacts[0].Name() != "Ada Lovelace" {
-		t.Fatalf("contacts = %#v", contacts)
-	}
-
-	_, err = decodeWithLimit(strings.NewReader(" "+padded), limit)
-	if err == nil || !strings.Contains(err.Error(), strconv.FormatInt(limit, 10)) {
-		t.Fatalf("expected %d-byte cap error, got %v", limit, err)
-	}
-
-	ndjson := `{"identifier":"a1","full_name":"Ada Lovelace"}`
-	cr := &countingReader{r: io.MultiReader(
-		io.LimitReader(repeatByteReader{b: ' '}, 4097),
-		strings.NewReader(ndjson+"\n"),
-	)}
-	_, err = decodeWithLimit(cr, 4096)
-	if err == nil || !strings.Contains(err.Error(), "4096") {
-		t.Fatalf("expected 4096-byte cap error, got %v", err)
-	}
-	if cr.n > 4097 {
-		t.Fatalf("read %d bytes; Decode slurped past the cap", cr.n)
-	}
-}
-
 type errReader struct{ err error }
 
 func (e errReader) Read([]byte) (int, error) { return 0, e.err }
 
-func TestDecodeErrorAndLimitBranches(t *testing.T) {
-	if _, err := Decode(errReader{errors.New("boom")}); err == nil || !strings.Contains(err.Error(), "boom") {
-		t.Fatalf("reader error = %v", err)
+func TestDecodeReaderErrors(t *testing.T) {
+	for _, prefix := range []string{"", " \n", "{}\n", "[", "[{", "[]", "[] \n"} {
+		boom := errors.New("boom")
+		if _, err := Decode(io.MultiReader(strings.NewReader(prefix), errReader{boom})); !errors.Is(err, boom) {
+			t.Fatalf("reader error after %q = %v", prefix, err)
+		}
 	}
-	if _, err := Decode(strings.NewReader("[")); err == nil {
-		t.Fatal("expected invalid JSON array error")
-	}
-	if _, err := Decode(strings.NewReader(`[{"identifier":"a1"}]{"identifier":"a2"}`)); err == nil {
-		t.Fatal("expected trailing JSON after array to fail")
-	}
-
-	const limit int64 = 64
-	if _, err := decodeWithLimit(strings.NewReader(`[{"identifier":"`+strings.Repeat("x", 200)), limit); err == nil || !strings.Contains(err.Error(), "64") {
-		t.Fatalf("expected truncated array cap error, got %v", err)
-	}
-
-	base := `[{"identifier":"a1","full_name":"Ada"}]`
-	if _, err := decodeWithLimit(strings.NewReader(base+strings.Repeat(" ", 200)), limit); err == nil || !strings.Contains(err.Error(), "64") {
-		t.Fatalf("expected array padding cap error, got %v", err)
-	}
-
-	prefix, suffix := `{"identifier":"`, `"}`
-	need := int(limit) + 1 - len(prefix) - len(suffix)
-	fat := prefix + strings.Repeat("x", need) + suffix
-	if _, err := decodeWithLimit(strings.NewReader(fat), limit); err == nil || !strings.Contains(err.Error(), "64") {
-		t.Fatalf("expected oversized NDJSON object cap error, got %v", err)
-	}
-
-	obj := `{"identifier":"a1"}`
-	padded := obj + strings.Repeat(" ", int(limit)+1-len(obj))
-	if _, err := decodeWithLimit(strings.NewReader(padded), limit); err == nil || !strings.Contains(err.Error(), "64") {
-		t.Fatalf("expected NDJSON whitespace cap error, got %v", err)
+	for _, input := range []string{"[", "[{}", "[{},]", "[{", "[]{}", "[] extra"} {
+		if _, err := Decode(strings.NewReader(input)); err == nil {
+			t.Fatalf("expected invalid array error for %q", input)
+		}
 	}
 }

--- a/internal/apple/darwin_test.go
+++ b/internal/apple/darwin_test.go
@@ -5,9 +5,24 @@ package apple
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 )
+
+func TestReadSystemPreservesLargeExport(t *testing.T) {
+	path := writeLargeContactExport(t, false)
+	orig := runSwiftContacts
+	t.Cleanup(func() { runSwiftContacts = orig })
+	runSwiftContacts = func(context.Context, string) ([]byte, error) {
+		return os.ReadFile(path)
+	}
+	contacts, err := ReadSystem(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkLargeContacts(t, contacts)
+}
 
 func TestReadSystemUsesSwiftRunner(t *testing.T) {
 	orig := runSwiftContacts

--- a/internal/apple/stream_test.go
+++ b/internal/apple/stream_test.go
@@ -1,0 +1,123 @@
+package apple
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeLargeContactExport(t *testing.T, array bool) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "contacts.json")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	write := func(value string) {
+		t.Helper()
+		if _, err := io.WriteString(f, value); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if array {
+		write("[")
+	}
+	for i := range 9 {
+		prefix := fmt.Sprintf(`{"identifier":"large-%d","full_name":"Contact %d","emails":["large-%d@example.com"],"unused":"`, i, i, i)
+		const suffix = "\"}\n"
+		const lineBytes = 75_498_408 / 9
+		if array && i > 0 {
+			write(",")
+		}
+		write(prefix)
+		write(strings.Repeat("x", lineBytes-len(prefix)-len(suffix)))
+		write(suffix)
+	}
+	if array {
+		write("]")
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !array {
+		info, err := os.Stat(path)
+		if err != nil || info.Size() != 75_498_408 {
+			t.Fatalf("large fixture size: info=%v err=%v", info, err)
+		}
+	}
+	return path
+}
+
+func checkLargeContacts(t *testing.T, contacts []Contact) {
+	t.Helper()
+	if len(contacts) != 9 {
+		t.Fatalf("decoded %d contacts, want 9", len(contacts))
+	}
+	for i, c := range contacts {
+		if c.Identifier != fmt.Sprintf("large-%d", i) || c.Name() != fmt.Sprintf("Contact %d", i) || len(c.Emails) != 1 || c.Emails[0] != fmt.Sprintf("large-%d@example.com", i) {
+			t.Fatalf("contact %d = %#v", i, c)
+		}
+	}
+}
+
+func TestReadFilePreservesLargeExports(t *testing.T) {
+	for _, array := range []bool{false, true} {
+		t.Run(fmt.Sprintf("array=%v", array), func(t *testing.T) {
+			contacts, err := ReadFile(writeLargeContactExport(t, array))
+			if err != nil {
+				t.Fatal(err)
+			}
+			checkLargeContacts(t, contacts)
+		})
+	}
+}
+
+func TestDecodePreservesNDJSONRecordLimit(t *testing.T) {
+	const maxLine = 16 << 20
+	prefix, suffix := `{"unused":"`, `","full_name":"Large Record"}`
+	for _, n := range []int{maxLine - 1, maxLine} {
+		line := prefix + strings.Repeat("x", n-len(prefix)-len(suffix)) + suffix
+		contacts, err := Decode(strings.NewReader(line + "\n"))
+		if n < maxLine {
+			if err != nil || len(contacts) != 1 {
+				t.Fatalf("below-limit record: contacts=%d err=%v", len(contacts), err)
+			}
+		} else if err == nil || !strings.Contains(err.Error(), "token too long") {
+			t.Fatalf("oversized NDJSON record: %v", err)
+		}
+		// JSON arrays never had the NDJSON scanner's per-record limit.
+		if contacts, err := Decode(strings.NewReader("[" + line + "]")); err != nil || len(contacts) != 1 {
+			t.Fatalf("array record: contacts=%d err=%v", len(contacts), err)
+		}
+	}
+}
+
+func TestDecodeDoesNotReadPastMalformedRecord(t *testing.T) {
+	for _, prefix := range []string{"{bad}\n", "[{bad},"} {
+		r := &countingReader{r: io.MultiReader(strings.NewReader(prefix), strings.NewReader(strings.Repeat(" ", 1<<20)))}
+		if _, err := Decode(r); err == nil {
+			t.Fatal("expected malformed record error")
+		}
+		if r.n >= 1<<20 {
+			t.Fatalf("read whole export before reporting malformed record: %d bytes", r.n)
+		}
+	}
+}
+
+func TestDecodePreservesNDJSONFraming(t *testing.T) {
+	for _, input := range []string{"{} {}\n", "{\n\"full_name\":\"Ada\"\n}\n"} {
+		if _, err := Decode(strings.NewReader(input)); err == nil {
+			t.Fatalf("accepted input that is not one JSON record per line: %q", input)
+		}
+	}
+	for _, input := range []string{"\u2003\n{\"full_name\":\"Ada\"}\n\u00a0", "\u2003[{\"full_name\":\"Ada\"}]\u00a0"} {
+		contacts, err := Decode(strings.NewReader(input))
+		if err != nil || len(contacts) != 1 || contacts[0].Name() != "Ada" {
+			t.Fatalf("outer whitespace: contacts=%#v err=%v", contacts, err)
+		}
+	}
+}


### PR DESCRIPTION
Apple contact exports were read and copied in full before decoding. Decode NDJSON one record at a time and JSON arrays one contact at a time, without imposing a total export-size ceiling. Preserve the existing 16 MiB NDJSON scanner limit, strict one-record-per-line framing, outer whitespace handling, and reader-error propagation.

The shared decoder supports both --input files and direct macOS imports. Decoded contacts remain in memory until import, and the direct macOS entrypoint still buffers the Swift helper output; the documentation states that boundary explicitly.

Regression and runtime proof uses a 75,498,408-byte synthetic nine-record NDJSON export. The real Go 1.26.6-built CLI imports nine distinct contacts through file input and the macOS entrypoint with a synthetic Swift runner, and also imports a large JSON array. Dry runs write no contacts. A subsequent oversized NDJSON record is rejected with token too long without persisting earlier records. Contacts.framework and real address books were not accessed.

The tests also cover the exact NDJSON scanner boundary, large JSON-array entries, strict framing, early malformed-record rejection, whitespace, and underlying read failures. The Unreleased entry thanks @SebTardif. This branch is rebased onto current main; final exact-head CI and review proof will be posted below.

Co-authored-by: Sebastien Tardif <sebtardif@ncf.ca>
