### PR TITLE
ci: refresh checkout and language setup actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@v7.0.0
         with:
           go-version-file: go.mod
           cache: true
@@ -71,10 +71,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Node
-        uses: actions/setup-node@v6.5.0
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: 24
 
@@ -86,10 +86,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@v7.0.0
         with:
           go-version-file: go.mod
           cache: true
@@ -141,10 +141,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@v7.0.0
         with:
           go-version-file: go.mod
           cache: true
@@ -168,12 +168,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@v7.0.0
         with:
           go-version-file: go.mod
           cache: true
@@ -206,12 +206,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@v7.0.0
         with:
           go-version-file: go.mod
           cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.1 - Unreleased
 
 - Updated Kong to 1.16.1, CrawlKit to 0.14.7, x/sys to 0.47.0, and CI checks while preserving the Go 1.26.6 minimum.
+- Updated ordinary CI to Checkout 7.0.1, Setup Go 7.0.0, and Setup Node 7.0.0.
 - Fixed `note add` hanging on inaccessible notes paths and corrected duplicate filename suffixes without limiting note counts. Thanks @SebTardif.
 - Hardened avatar storage and vCard avatar reads against symlink escapes, and made avatar and vCard file replacement private and atomic.
 - Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -69,7 +69,7 @@ policy migration, not an action performed by candidate code or ordinary builds.
 ## 1) Local proof
 
 ```bash
-go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1 run
+go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2 run
 go test -count=1 ./... -coverprofile=coverage.out
 go tool cover -func=coverage.out | tail -n 1
 go test -count=1 -race ./...


### PR DESCRIPTION
Refresh ordinary CI to Checkout 7.0.1, Setup Go 7.0.0, and Setup Node 7.0.0. Keep Go 1.26.6, Node 24, the existing cache behavior, and the separate protected release workflow unchanged. Align the documented local linter command with CI's 2.13.2 pin.

CrawlKit 0.14.9 requires Go 1.27, so 0.14.7 remains the newest compatible version under the repository's current Go minimum. The other modules used by the built CLI are current. Artifact upload/download action majors in the protected signing/publication lane are held for that lane's separate end-to-end proof.

Validation: Go 1.26.6 all-package coverage and race tests, eight site-tooling tests, release-script checks with isolated mocks, module verification, and a built CLI smoke run. Codex autoreview checks P0–P2 findings. Exact-head GitHub CI provides the real runner proof for the action upgrades; final results will be posted below.
