### PR TITLE
docs: prepare complete 0.2.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Highlights:** Import contacts from compatible local crawlers, with safer matching, local-only setup, and more reliable archive maintenance.
 - Added `import contacts --from` for compatible crawler exports, including Telecrawl and Wacrawl, with per-source evidence, normalized phone deduplication, idempotent imports, and safeguards against name-only and cross-person joins. Thanks @joshp123.
 - Made initialization local-only by default; backup remotes are configured explicitly. Thanks @TeodoroRodrigo.
+- Streamed Apple contact export decoding without a total size ceiling, preserving large file and macOS imports and the existing 16 MiB NDJSON record limit. Thanks @SebTardif.
 - Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.
 - Hardened avatar storage and vCard avatar reads against symlink escapes, and made avatar and vCard file replacement private and atomic.
 - Capped manual avatar reads at 10 MiB while preserving oversized legacy avatar metadata and import protection during Doctor repair. Thanks @SebTardif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 0.2.0 - Unreleased
 
-**Highlights:** Import contacts from compatible local crawlers, with safer matching, local-only setup, and more reliable archive maintenance.
-
+- **Highlights:** Import contacts from compatible local crawlers, with safer matching, local-only setup, and more reliable archive maintenance.
 - Added `import contacts --from` for compatible crawler exports, including Telecrawl and Wacrawl, with per-source evidence, normalized phone deduplication, idempotent imports, and safeguards against name-only and cross-person joins. Thanks @joshp123.
 - Made initialization local-only by default; backup remotes are configured explicitly. Thanks @TeodoroRodrigo.
 - Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,23 @@
 # Changelog
 
-## 0.1.1 - Unreleased
+## 0.2.0 - Unreleased
 
-- Fixed vCard export hanging on long salvaged names containing invalid UTF-8 bytes. Thanks @SebTardif.
-- Updated Kong to 1.16.1, CrawlKit to 0.14.7, x/sys to 0.47.0, and CI checks while preserving the Go 1.26.6 minimum.
-- Updated ordinary CI to Checkout 7.0.1, Setup Go 7.0.0, and Setup Node 7.0.0.
-- Fixed `note add` hanging on inaccessible notes paths and corrected duplicate filename suffixes without limiting note counts. Thanks @SebTardif.
+**Highlights:** Import contacts from compatible local crawlers, with safer matching, local-only setup, and more reliable archive maintenance.
+
+- Added `import contacts --from` for compatible crawler exports, including Telecrawl and Wacrawl, with per-source evidence, normalized phone deduplication, idempotent imports, and safeguards against name-only and cross-person joins. Thanks @joshp123.
+- Made initialization local-only by default; backup remotes are configured explicitly. Thanks @TeodoroRodrigo.
+- Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.
 - Hardened avatar storage and vCard avatar reads against symlink escapes, and made avatar and vCard file replacement private and atomic.
 - Capped manual avatar reads at 10 MiB while preserving oversized legacy avatar metadata and import protection during Doctor repair. Thanks @SebTardif.
-- Streamed Apple contact export decoding without a total size ceiling, preserving large file and macOS imports and the existing 16 MiB NDJSON record limit. Thanks @SebTardif.
-- Enforced the global `--dry-run` no-write contract across initialization, config, people, notes, imports, vCard export, Git helpers, doctor repairs, and automatic repair.
-- Updated to Go 1.26.6 and CrawlKit 0.13.4 to resolve Go standard-library vulnerabilities GO-2026-5856, GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
-- Fixed Unicode-safe search snippets, live Discrawl WAL reads, unexpected person-directory errors, and tagged `go install` version reporting.
+- Fixed vCard export hanging on long salvaged names containing invalid UTF-8 bytes. Thanks @SebTardif.
+- Fixed `note add` hanging on inaccessible notes paths and corrected duplicate filename suffixes without limiting note counts. Thanks @SebTardif.
+- Stopped Google imports from looping on repeated pagination tokens, with a 500-page safety ceiling that preserves larger terminating imports. Thanks @SebTardif.
 - Added a dedicated 20-second HTTP timeout for Google avatar downloads while preserving earlier caller cancellation. Thanks @SebTardif.
-- Replaced legacy CI publication with a credential-free, read-only mounted release driver, locally Foundation-signed and notarized Darwin artifacts, protected-default-branch signed-tag-object reproduction, exact embedded-requirement, provenance, signature, online notarization, sealed-snapshot publication, and downstream re-download verification.
+- Fixed Unicode-safe search snippets, live Discrawl WAL reads, unexpected person-directory errors, and tagged `go install` version reporting.
+- Hardened documentation rendering and third-party asset loading, and preserved metadata in the generated LLM documentation index. Thanks @vincentkoc.
+- Updated to Go 1.26.6 to resolve Go standard-library vulnerabilities GO-2026-5856, GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218; refreshed Kong to 1.16.1, CrawlKit to 0.14.7, and x/sys to 0.47.0.
+- Updated CI checks and tooling, including Checkout 7.0.1, Setup Go 7.0.0, and Setup Node 7.0.0, while preserving the Go 1.26.6 minimum.
+- Replaced legacy CI publication with Foundation-signed and notarized Darwin artifacts, authenticated signed-tag builds, protected verification and publication, sealed asset snapshots, and downstream integrity checks; Homebrew updates remain a separate release step.
 
 ## 0.1.0 - 2026-05-08
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -107,7 +107,7 @@ git push origin main vX.Y.Z
 The remote tag must be an annotated tag whose embedded `tag` header exactly
 matches `vX.Y.Z`, resolve to the reviewed release commit, and carry the approved
 SSH signature. This prevents a correctly signed tag object from being replayed
-under a different ref name. This v0.1 release lane accepts stable `vX.Y.Z` tags
+under a different ref name. This release lane accepts stable `vX.Y.Z` tags
 only; prereleases require a separate metadata-aware process. The credentialed
 packager never executes code or policy from that tag before authenticating it.
 

--- a/scripts/test-clawdex-release.sh
+++ b/scripts/test-clawdex-release.sh
@@ -745,7 +745,7 @@ release_body=$(awk '
   /^## 0\.1\.1([[:space:]]|$)/ { in_release = 1; next }
   in_release && /^## / { exit }
   in_release && /^- / { print }
-' "$ROOT/CHANGELOG.md")
+' "$WORK_DIR/release-changelog.md")
 release_body+=$'\n\n'
 jq -n --arg body "$release_body" \
   '[{id: 42, tag_name: "v0.1.1", draft: true, prerelease: false, immutable: false, body: $body}]' \

--- a/scripts/test-clawdex-release.sh
+++ b/scripts/test-clawdex-release.sh
@@ -437,7 +437,7 @@ unset GH_TOKEN GITHUB_TOKEN
 
 write_finalized_changelog() {
   awk '
-    /^## 0\.1\.1 - Unreleased$/ { print "## 0.1.1 - 2026-07-09"; next }
+    /^## [0-9]+\.[0-9]+\.[0-9]+ - Unreleased$/ { print "## 0.1.1 - 2026-07-09"; next }
     { print }
   ' "$ROOT/CHANGELOG.md" > "$WORK_DIR/release-changelog.md"
 }


### PR DESCRIPTION
Prepare the single complete 0.2.0 Unreleased section since v0.1.0. The crawler-contact import feature warrants a minor release. Preserve contributor credit, keep Highlights first, and order the notes by user interest.

Rebased onto main after #11, #12, #14, and #16 landed. The Apple streaming note now follows local-only initialization and describes the compatibility-preserving rewrite in #15. Land this PR after #15. No tag or publication is part of this preparation.

Actual release-note preparation proof: copied the current changelog into a temporary finalized 0.2.0 preview, then ran the production packager's awk/jq extraction against that file. All 16 of 16 bullets were preserved, Highlights remained first, the Apple streaming note appeared once, and the released 0.1.0 section remained byte-for-byte unchanged. The generated JSON SHA-256 was fabe4fd13feb851eb5d2fe00e139f49867ca3f1ca2b1a252dfe99c47541e4c32. The repository changelog remains Unreleased.

The synthetic release-script fixtures retain their fixed 0.1.1 version but derive both source notes and the API response from the finalized fixture changelog. Final exact-head CI, release-script tests, and Codex autoreview evidence will be posted below. Signing, notarization, protected publication, clean-VM Gatekeeper proof, and Homebrew verification remain release-time gates.
