### PR TITLE
fix(build): strip host paths from release binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,8 @@ builds:
     binary: clawdex
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
       - -s -w -X github.com/openclaw/clawdex/internal/cli.Version={{ .Version }}
     targets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Made release binaries reproducible across checkout and dependency-cache locations so the independent rebuild gate can verify them before publication.
+
 ## 0.2.0 - 2026-09-06
 
 - **Highlights:** Import contacts from compatible local crawlers, with safer matching, local-only setup, and more reliable archive maintenance.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -27,6 +27,10 @@ GoReleaser linker flags; tagged `go install` builds use Go module metadata.
 Keep the `dev` source default rather than hardcoding a released version.
 These checks belong to the shared workflow, alongside the exact-commit CI gate.
 
+Keep `-trimpath` in the GoReleaser build flags. The independent rebuild uses a
+different checkout and module-cache directory; embedding either absolute path
+makes otherwise equivalent binaries fail the byte-for-byte comparison.
+
 Local checks and snapshots need no signing credentials:
 
 ```bash


### PR DESCRIPTION
The 0.2.0 release stopped at the independent rebuild gate because the GoReleaser configuration embedded absolute checkout and dependency-cache paths. The primary build and isolated rebuild use different directories, so otherwise equivalent Linux binaries had different bytes. The CI cross-build already used `-trimpath`, but the release configuration did not.

Pass `-trimpath` through GoReleaser, document why it must remain enabled, and record the fix under Unreleased. This preserves the independent byte-comparison gate.

Validation:
- Reproduced different Linux arm64 binary bytes from two checkout directories and separate module caches using the original GoReleaser configuration.
- With this change, both Linux arm64 and Darwin arm64 binaries were byte-identical across the two directories using Go 1.26.6 and the actual GoReleaser configuration.
- Ran the native Darwin snapshot binary with `--version` and `--help`.
- Full Go test suite, all eight Node tests, and `goreleaser check` passed.
- Independent autoreview of the local change was clean through P2.

Failed release run: https://github.com/openclaw/clawdex/actions/runs/34074010093

The existing `v0.2.0` tag remains at `2b3628aa43d59abd947e089ad733cddd064034f8`. No GitHub Release was published, and the tag has not been moved. A subsequent publication needs a release-version decision after this fix lands.
