### PR TITLE
fix(markdown): strip Windows volume from repair backup paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,28 @@ jobs:
           ./bin/clawdex --config "$cfg" --plain search release | grep -q "CI Person"
           ./bin/clawdex --config "$cfg" doctor --repair --dry-run
 
+  windows-repair:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Test native repair paths
+        run: go test -count=1 ./internal/markdown
+
+      - name: Build
+        run: go build -o bin/clawdex.exe ./cmd/clawdex
+
+      - name: Smoke test repair and backup preservation
+        run: node scripts/smoke-repair.mjs ./bin/clawdex.exe
+
   deps:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -361,7 +361,7 @@ func backupOriginal(path, repairRoot string) error {
 	if err != nil {
 		return err
 	}
-	rel := strings.TrimPrefix(filepath.Clean(path), string(filepath.Separator))
+	rel := repairBackupRel(path)
 	dest := filepath.Join(repairRoot, time.Now().UTC().Format("20060102T150405Z"), rel)
 	if !strings.HasPrefix(dest, filepath.Clean(repairRoot)+string(filepath.Separator)) {
 		return fmt.Errorf("repair backup escaped repair root: %s", dest)
@@ -371,6 +371,12 @@ func backupOriginal(path, repairRoot string) error {
 	}
 	// #nosec G703 -- dest is constrained to repairRoot above.
 	return os.WriteFile(dest, data, 0o600)
+}
+
+func repairBackupRel(path string) string {
+	clean := filepath.Clean(path)
+	rel := strings.TrimPrefix(clean, filepath.VolumeName(clean))
+	return strings.TrimPrefix(rel, string(filepath.Separator))
 }
 
 func salvagePerson(front string) model.Person {

--- a/internal/markdown/markdown_test.go
+++ b/internal/markdown/markdown_test.go
@@ -92,7 +92,7 @@ func TestBackupOriginalDoesNotCreateVolumeSegment(t *testing.T) {
 		if relErr != nil {
 			return relErr
 		}
-		for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		for part := range strings.SplitSeq(rel, string(filepath.Separator)) {
 			if strings.HasSuffix(part, ":") {
 				t.Fatalf("backup path created volume segment %q: %q", part, walked)
 			}
@@ -127,7 +127,7 @@ func TestRepairBackupRelStripsVolumeName(t *testing.T) {
 	if filepath.IsAbs(rel) {
 		t.Fatalf("backup rel is still absolute: %q from %q", rel, path)
 	}
-	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+	for part := range strings.SplitSeq(rel, string(filepath.Separator)) {
 		if strings.HasSuffix(part, ":") {
 			t.Fatalf("volume-like segment %q in backup rel %q from %q", part, rel, path)
 		}

--- a/internal/markdown/markdown_test.go
+++ b/internal/markdown/markdown_test.go
@@ -65,6 +65,75 @@ func TestPersonRepairSalvagesBrokenFrontmatter(t *testing.T) {
 	}
 }
 
+func TestBackupOriginalDoesNotCreateVolumeSegment(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "people", "ada", "person.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := "---\nid: person_1\nname: Ada Lovelace\ntags: [math\n---\n# Ada\n"
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p, report, err := ReadPerson(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repairRoot := filepath.Join(dir, ".clawdex", "repairs")
+	if err := RepairPerson(path, repairRoot, p, report, true); err != nil {
+		t.Fatal(err)
+	}
+	var backups []string
+	err = filepath.WalkDir(repairRoot, func(walked string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(repairRoot, walked)
+		if relErr != nil {
+			return relErr
+		}
+		for _, part := range strings.Split(rel, string(filepath.Separator)) {
+			if strings.HasSuffix(part, ":") {
+				t.Fatalf("backup path created volume segment %q: %q", part, walked)
+			}
+		}
+		if !d.IsDir() {
+			backups = append(backups, walked)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("backups = %v", backups)
+	}
+	got, err := os.ReadFile(backups[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != original {
+		t.Fatalf("backup = %q", got)
+	}
+}
+
+func TestRepairBackupRelStripsVolumeName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "people", "ada", "person.md")
+	rel := repairBackupRel(path)
+	if vol := filepath.VolumeName(rel); vol != "" {
+		t.Fatalf("backup rel kept volume %q: %q from %q", vol, rel, path)
+	}
+	if filepath.IsAbs(rel) {
+		t.Fatalf("backup rel is still absolute: %q from %q", rel, path)
+	}
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		if strings.HasSuffix(part, ":") {
+			t.Fatalf("volume-like segment %q in backup rel %q from %q", part, rel, path)
+		}
+	}
+}
+
 func TestReadPersonMissingFrontmatterInfersNameFromHeading(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "people", "ada", "person.md")

--- a/scripts/smoke-repair.mjs
+++ b/scripts/smoke-repair.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const binary = resolve(process.argv[2]);
+const scratch = mkdtempSync(join(tmpdir(), "clawdex-repair-"));
+const config = join(scratch, "config.toml");
+const repo = join(scratch, "contacts");
+function run(...args) {
+  const result = spawnSync(binary, ["--config", config, "--repo", repo, "--json", ...args], {
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+  assert.ifError(result.error);
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+try {
+  run("init", repo, "--remote", "");
+  const personDir = join(repo, "people", "ada");
+  mkdirSync(personDir, { recursive: true });
+  const person = join(personDir, "person.md");
+  const original = "---\nid: person_1\nname: Ada Lovelace\ntags: [math\n---\n# Ada\n";
+  writeFileSync(person, original);
+  assert.equal(run("doctor", "--repair").repaired, 1);
+  const repairs = join(repo, ".clawdex", "repairs");
+  const backups = readdirSync(repairs, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile());
+  assert.equal(backups.length, 1);
+  assert.equal(readFileSync(join(backups[0].parentPath, backups[0].name), "utf8"), original);
+  assert.notEqual(readFileSync(person, "utf8"), original);
+  assert.equal(run("doctor", "--repair").repaired, 0);
+  assert.equal(run("person", "show", "person_1").name, "Ada Lovelace");
+  console.log("PASS: doctor repaired the contact, preserved the original backup, and is idempotent.");
+} finally {
+  rmSync(scratch, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What Problem This Solves

On Windows, `clawdex doctor --repair` (and default AutoRepair on
`clawdex person list`) fails before it can rewrite a damaged
`person.md`. `backupOriginal` only strips a leading path separator,
then `filepath.Join`s the still-absolute `C:\...` person path under
`.clawdex/repairs/<timestamp>/`. `MkdirAll` tries to create a `C:`
directory component and returns:

```text
mkdir ...\TIMESTAMP\C:: The filename, directory name, or volume label syntax is incorrect.
```

Default `BackupBeforeRepair` is true, so every repair hits this path.
The bug has been in `backupOriginal` since the CLI bootstrap
([`fc837601e1`](https://github.com/openclaw/clawdex/commit/fc837601e1),
2026-05-08). Recent merged PRs [#11](https://github.com/openclaw/clawdex/pull/11)
through [#15](https://github.com/openclaw/clawdex/pull/15) cover avatar
reads, Google HTTP timeouts, Apple streaming, and vCard fold. They do
not touch repair backups.

## Evidence

Built `clawdex` from this branch and from unpatched `origin/main`.
Initialized a contacts repo under `%TEMP%\clawdex-f007-repair`, wrote
`people\ada\person.md` with broken YAML (`tags: [math` unclosed), and
ran the public repair command.

Unpatched binary, same fixture:

```console
$ clawdex --config config.toml --repo contacts --plain doctor --repair
mkdir C:\Users\sebta\AppData\Local\Temp\clawdex-f007-unpatched\contacts\.clawdex\repairs\20260907T204752Z\C:: The filename, directory name, or volume label syntax is incorrect.
exit: 1
```

A `go run` of the dest-shape helper on the same person path shows why:

```console
$ go run proof-f007-path.go <person.md> <repairs>
person path: C:\Users\sebta\AppData\Local\Temp\clawdex-f007-repair\contacts\people\ada\person.md
volume: "C:"
old dest: ...\repairs\20260907T204728Z\C:\Users\sebta\...\people\ada\person.md
new dest: ...\repairs\20260907T204728Z\Users\sebta\...\people\ada\person.md
old has volume segment: true
new has volume segment: false
```

Patched binary, same command:

```console
$ clawdex --config config.toml --repo contacts --plain doctor --repair
avatar_repaired: 0
dry_run: false
git_dirty: true
people: 1
repaired: 1
```

Backup tree under `.clawdex\repairs` (no `C:` segment):

```console
20260907T204728Z
20260907T204728Z\Users
20260907T204728Z\Users\sebta\AppData\Local\Temp\clawdex-f007-repair\contacts\people\ada\person.md
```

`no volume segment in backup tree`. Backup file is 56 bytes (the original damaged `person.md`).

## Real behavior proof

- **Behavior or issue addressed:** Windows repair backup no longer joins a drive letter as a directory. `doctor --repair` copies the original `person.md` under `.clawdex\repairs\<timestamp>\Users\...` and rewrites the person file.
- **Real environment tested:** Windows amd64, Go 1.27.0, clawdex built from this branch to `bin\clawdex.exe`, isolated config under `%TEMP%\clawdex-f007-repair`. Unpatched compare binary built from `origin/main` at `5a01d6b`.
- **Exact steps or command run after this patch:**

  ```bash
  clawdex --config config.toml init contacts
  write people\ada\person.md with broken YAML frontmatter
  go run proof-f007-path.go people\ada\person.md contacts\.clawdex\repairs
  clawdex --config config.toml --repo contacts --plain doctor --repair
  ```

- **Evidence after fix:** terminal output from the patched binary and dest-shape helper:

  ```console
  $ clawdex --config config.toml --repo contacts --plain doctor --repair
  repaired: 1
  ```

  ```console
  $ go run proof-f007-path.go <person.md> <repairs>
  volume: "C:"
  old dest: ...\TIMESTAMP\C:\Users\sebta\...\person.md
  new dest: ...\TIMESTAMP\Users\sebta\...\person.md
  old has volume segment: true
  new has volume segment: false
  ```

  Backup listing after repair starts `20260907T204728Z\Users\...` and has no `C:` component. Unpatched `doctor --repair` on the same fixture exited 1 with `mkdir ...\TIMESTAMP\C::`.

- **Observed result after fix:** Repair returns `repaired: 1`. The backup file exists under a relative path that starts with `Users`, not `C:`. The damaged original is preserved (56 bytes).
- **What was not tested:** UNC `\\server\share` person paths, and `doctor --repair` on a drive-relative `C:foo` path without a separator.

## Summary

`repairBackupRel` strips `filepath.VolumeName` plus the following
separator before `Join`. Unix paths are unchanged (empty volume, leading
`/` still trimmed). CHANGELOG is release-owned and is not edited here.
