### PR TITLE
chore: prepare 0.2.2 notes and refresh Go tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install analyzers
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@v0.8.1
-          go install mvdan.cc/gofumpt@v0.11.0
+          go install mvdan.cc/gofumpt@v0.12.0
           go install github.com/securego/gosec/v2/cmd/gosec@v2.29.0
           go install golang.org/x/tools/cmd/deadcode@v0.49.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Highlights:** Repair damaged contacts reliably on Windows and optionally skip large Apple thumbnails without interrupting contact imports.
+- Fixed Windows contact repair backups failing on drive-letter paths; added native Windows CLI coverage for original-file preservation and repeat repairs. Thanks @SebTardif.
+- Added `import apple --avatars --max-avatar-bytes N` to skip oversized incoming thumbnails with a warning while preserving existing avatars and continuing contact imports; the default remains unlimited, and dry runs apply the same filter. Thanks @SebTardif.
+- Updated the Go 1.26 toolchain to 1.26.8 and gofumpt to 0.12.0 while preserving the existing macOS support baseline.
+
 ## 0.2.1 - 2026-09-06
 
 0.2.0 was tagged by a failed automated run but never published as a GitHub Release; its assets and release notes ship as 0.2.1.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/clawdex
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/alecthomas/kong v1.16.1


### PR DESCRIPTION
Prepare the next patch notes after the Windows repair fix (#20) and optional Apple avatar byte limit (#21), keeping all changelog edits in this final PR. **Land #20 and #21 first, then this PR.**

Update Go from 1.26.6 to 1.26.8 and gofumpt from 0.11.0 to 0.12.0. CrawlKit 0.14.8 and 0.14.9 require Go 1.27; hold that update because Go 1.27 drops support for macOS versions before Ventura. Other direct modules and Actions pins remain current.

Validation: full Go 1.26.8 test suite, race tests, vet, module verification/tidy, site tests, actionlint, gofumpt, and a real built CLI exercising initialization, contact add/show, notes, search, vCard export, and doctor. Exact-head CI and autoreview are recorded in the proof comment.

Recommend patch 0.2.2 after these PRs land and the resulting main commit passes CI. This PR does not tag, publish, or change released changelog sections.
