### PR TITLE
fix(git): preserve unpublished contacts when pulling

### DIFF
--- a/docs/git-sync.md
+++ b/docs/git-sync.md
@@ -50,8 +50,10 @@ created — if there were no changes, `committed: false`.
 clawdex git pull
 ```
 
-Pulls from the configured remote on the configured branch. Resolve
-conflicts the way you'd resolve them in any other repo.
+Pulls from the configured remote on the configured branch using fast-forward-only
+updates. Unpublished local commits are preserved. If local and remote history
+have diverged, the command fails without resetting the local branch; reconcile
+the histories with Git before retrying.
 
 ### Push
 

--- a/internal/repo/git.go
+++ b/internal/repo/git.go
@@ -19,7 +19,14 @@ func (r Repo) Pull(ctx context.Context) error {
 	if err := r.requireRemote(ctx); err != nil {
 		return err
 	}
-	return mirror.PullCurrent(ctx, r.MirrorOptions())
+	opts := r.MirrorOptions()
+	if err := mirror.EnsureRepo(ctx, opts); err != nil {
+		return err
+	}
+	// CrawlKit 0.14.7 resets the branch when PullCurrent receives a remote URL.
+	// Configure origin first, then use its fast-forward-only path.
+	opts.Remote = ""
+	return mirror.PullCurrent(ctx, opts)
 }
 
 func (r Repo) Push(ctx context.Context) error {

--- a/internal/repo/repo_test.go
+++ b/internal/repo/repo_test.go
@@ -180,11 +180,86 @@ func TestRepoInitGuardsAndRemoteLocal(t *testing.T) {
 	}
 }
 
-func runGit(t *testing.T, dir string, args ...string) {
+func TestPullPreservesLocalHistory(t *testing.T) {
+	for _, configuredRemote := range []bool{true, false} {
+		for _, scenario := range []string{"ahead", "diverged", "fast-forward"} {
+			name := scenario + "/origin-only"
+			if configuredRemote {
+				name = scenario + "/configured-remote"
+			}
+			t.Run(name, func(t *testing.T) {
+				dir := t.TempDir()
+				remote := filepath.Join(dir, "remote.git")
+				runGit(t, dir, "init", "--bare", "--initial-branch=contacts", remote)
+				cfg := DefaultConfig()
+				cfg.RepoPath = filepath.Join(dir, "local")
+				cfg.Git.Remote = remote
+				cfg.Git.Branch = "contacts"
+				r := Open(cfg.RepoPath, cfg)
+				if err := r.Init(t.Context()); err != nil {
+					t.Fatal(err)
+				}
+				if committed, err := r.Commit(t.Context(), "test: initial contacts"); err != nil || !committed {
+					t.Fatalf("initial commit=%v err=%v", committed, err)
+				}
+				if err := r.Push(t.Context()); err != nil {
+					t.Fatal(err)
+				}
+				writer := filepath.Join(dir, "writer")
+				runGit(t, dir, "clone", remote, writer)
+				if scenario != "fast-forward" {
+					if err := os.WriteFile(filepath.Join(r.Path, "local-note.md"), []byte("unpublished note\n"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					if committed, err := r.Commit(t.Context(), "test: unpublished note"); err != nil || !committed {
+						t.Fatalf("local commit=%v err=%v", committed, err)
+					}
+				}
+				before := runGit(t, r.Path, "rev-parse", "HEAD")
+				if scenario != "ahead" {
+					if err := os.WriteFile(filepath.Join(writer, "remote-note.md"), []byte("remote note\n"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					other := Open(writer, cfg)
+					if committed, err := other.Commit(t.Context(), "test: remote note"); err != nil || !committed {
+						t.Fatalf("remote commit=%v err=%v", committed, err)
+					}
+					runGit(t, writer, "push", "origin", "contacts")
+				}
+				if configuredRemote {
+					// The configured URL must still replace a stale origin before pulling.
+					runGit(t, r.Path, "remote", "set-url", "origin", filepath.Join(dir, "stale.git"))
+				} else {
+					r.Config.Git.Remote = ""
+				}
+				err := r.Pull(t.Context())
+				if (err != nil) != (scenario == "diverged") {
+					t.Fatalf("pull %s: %v", scenario, err)
+				}
+				wantHead := before
+				if scenario == "fast-forward" {
+					wantHead = runGit(t, writer, "rev-parse", "HEAD")
+				} else {
+					data, err := os.ReadFile(filepath.Join(r.Path, "local-note.md"))
+					if err != nil || string(data) != "unpublished note\n" {
+						t.Fatalf("local note lost: %q err=%v", data, err)
+					}
+				}
+				if got := runGit(t, r.Path, "rev-parse", "HEAD"); got != wantHead {
+					t.Fatalf("HEAD changed unexpectedly: got %s want %s", got, wantHead)
+				}
+			})
+		}
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.CommandContext(t.Context(), "git", args...)
 	cmd.Dir = dir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, out)
 	}
+	return strings.TrimSpace(string(out))
 }


### PR DESCRIPTION
## Problem

With a configured backup remote, `clawdex git pull` could silently remove unpublished contact commits from the local branch. CrawlKit 0.14.7 routes `PullCurrent` to its mirror-reset operation whenever the options contain a remote URL, including when histories diverge.

## Change

Configure origin first, then invoke CrawlKit's existing fast-forward-only pull path without the URL option. This retains configured remote and branch selection, preserves unpublished commits, and fails on divergent history. Keep Go 1.26.8 and the existing platform baseline. Document the pull contract and cover ahead, divergent, and fast-forward histories with configured and origin-only remotes, including replacement of a stale origin.

The changelog entry is reserved for the final notes/dependency PR so independently based PRs do not conflict.

## Validation

- Reproduced both local-ahead and divergent-history contact loss using the real pre-fix CLI and synthetic local bare remotes.
- Built CLI after the fix: local-ahead contacts survive; divergent pull exits 1 without moving the local tip; fast-forward pull imports the remote contact.
- Go 1.26.8 full tests with coverage, race tests, vet, and Node site tests; exact results and CI linked in the proof comment.
- Independent autoreview required before land.

## Captured runtime evidence

Exact source head: `f516ee90be0d45903ec98f9da56c9310a1d3df17`. Built with `GOTOOLCHAIN=go1.26.8 go build -trimpath -o clawdex ./cmd/clawdex`. The script initialized fresh contact repositories and local bare remotes, seeded/pushed the initial contact, then added unpublished and/or remote contacts through the production CLI. No private data or remote services were used.

Captured stdout (fixture paths normalized):

```text
PASS ahead: return=0; history and contacts preserved.
{"fresh_init_and_initial_push": "passed", "head_after": "aae9850ef2856dfd6314984305086c85c7fcc0bd", "head_before": "aae9850ef2856dfd6314984305086c85c7fcc0bd", "pull_exit": 0, "remote_head": "42d1bc1098f1a721a210525c4500866b0542c871", "scenario": "ahead", "stderr": "", "unpublished_contact_preserved": true}
PASS diverged: return=1; history and contacts preserved.
{"fresh_init_and_initial_push": "passed", "head_after": "b45b0f64009e22dbdbb866b9513fb76cf9c84af4", "head_before": "b45b0f64009e22dbdbb866b9513fb76cf9c84af4", "pull_exit": 1, "remote_head": "2880ef87d5344f0820c2f1c58e583f467e787dfb", "scenario": "diverged", "stderr": "git pull --ff-only origin main: exit status 128\nFrom <fixture>/remote\n * branch            main       -> FETCH_HEAD\nhint: Diverging branches can't be fast-forwarded, you need to either:\nhint:\nhint: \tgit merge --no-ff\nhint:\nhint: or:\nhint:\nhint: \tgit rebase\nhint:\nhint: Disable this message with \"git config set advice.diverging false\"\nfatal: Not possible to fast-forward, aborting.", "unpublished_contact_preserved": true}
PASS fast-forward: return=0; history and contacts preserved.
{"fresh_init_and_initial_push": "passed", "head_after": "382f7759ce0a4023d999ec97e5e5f1714e0d72da", "head_before": "a782dec438e220ea45c87b7e2c030163f38fad22", "pull_exit": 0, "remote_head": "382f7759ce0a4023d999ec97e5e5f1714e0d72da", "scenario": "fast-forward", "stderr": "", "unpublished_contact_preserved": null}
```

Full tests, CI, regression reproduction, and combined-dependency verification: https://github.com/openclaw/clawdex/pull/23#issuecomment-5640761000

Independent local and branch autoreview were scoped-clean through P2. CI is fully green on the exact source head. Merge this PR first, then #24 for the changelog and dependency refresh.
