### PR TITLE
chore: refresh dependencies and prepare 0.2.3 notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           go install honnef.co/go/tools/cmd/staticcheck@v0.8.1
           go install mvdan.cc/gofumpt@v0.12.0
           go install github.com/securego/gosec/v2/cmd/gosec@v2.29.0
-          go install golang.org/x/tools/cmd/deadcode@v0.49.0
+          go install golang.org/x/tools/cmd/deadcode@v0.50.0
 
       - name: Vet
         run: go vet ./...
@@ -180,7 +180,7 @@ jobs:
           git diff --exit-code -- go.mod go.sum
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.8.0
 
       - name: Run govulncheck
         run: '"$(go env GOPATH)/bin/govulncheck" ./...'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- **Highlights:** Keep unpublished contacts safe when pulling from a configured backup remote.
+- Fixed `git pull` discarding unpublished local commits when `git.remote` is configured; pulls now preserve local history and reject divergence instead of resetting the branch.
+- Updated x/sys to 0.48.0, deadcode to 0.50.0, and govulncheck to 1.8.0 while retaining Go 1.26.8 and the existing macOS support baseline.
+
 ## 0.2.2 - 2026-09-07
 
 - **Highlights:** Repair damaged contacts reliably on Windows and optionally skip large Apple thumbnails without interrupting contact imports.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.16.1
 	github.com/google/uuid v1.6.0
 	github.com/openclaw/crawlkit v0.14.7
-	golang.org/x/sys v0.47.0
+	golang.org/x/sys v0.48.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/openclaw/crawlkit v0.14.7 h1:Kvceob5WyEtrGt4YkwKRcepU77g7FX/HPTRIiCe+
 github.com/openclaw/crawlkit v0.14.7/go.mod h1:iDnctBAFtqB5l2sHREfpyjQwifToeebDVdVJvZWVLn0=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
-golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
-golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.48.0 h1:bbX/i/6MgT9BVLM9RT1thmxL04yeTAhbEz4SyadbXoo=
+golang.org/x/sys v0.48.0/go.mod h1:hNLxWAXmnKAxqDtdwIYC4bM9oQPEecfsnNMuSxOs3og=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Change

Refresh x/sys to 0.48.0, deadcode to 0.50.0, and govulncheck to 1.8.0 while retaining Go 1.26.8 and the current platform baseline. The full Unreleased notes also cover the unpublished-contact preservation fix in #23.

Merge #23 first, then this PR. Both branches start independently from main; only this PR edits the changelog. Recommend 0.2.3 as a patch release after both land.

CrawlKit remains at 0.14.7 because every newer release requires Go 1.27. Its relevant pull fix is implemented in #23 without raising the platform baseline. Other compiled runtime dependencies and the pinned Actions versions are current.

## Validation

- Go 1.26.8 full tests, race tests, vet, module verification, tidy consistency, workflow validation, and all eight Node site tests.
- Updated deadcode found no dead code; updated govulncheck reported no vulnerabilities.
- Real built CLI repaired a synthetic damaged contact, preserved its original backup, and completed a second repair without changes.
- Also built #23 with this PR's module files and ran local-ahead, divergent-history, and fast-forward pull scenarios against synthetic bare Git remotes.
- Exact CI and independent autoreview results follow in the proof comment.

The historical v0.2.2 release run failed only in Homebrew formula verification after publication and a successful tap update. Its shared verifier was fixed upstream in release-workflows 1.8.2. A newly authorized release must provide the fresh green full-pipeline proof; this PR does not dispatch a release or rewrite the published tag.

## Captured runtime evidence

Exact head: `8573488339254ad779a9bb106c5a5be363a84c62`. On Go 1.26.8, built `./cmd/clawdex` and ran `node scripts/smoke-repair.mjs ./clawdex` against synthetic contacts. Captured output:

```text
PASS: doctor repaired the contact, preserved the original backup, and is idempotent.
```

The smoke script runs the production CLI, verifies the original backup bytes, checks that the repaired contact remains readable, and confirms a repeated repair makes no change.

CI: https://github.com/openclaw/clawdex/actions/runs/34648733129 (all seven jobs passed; CodeQL also passed).

Both local and branch independent autoreviews are scoped-clean through P2. Local coverage is 90.5%; the full race suite, eight Node tests, module checks, and updated analyzers passed. Govulncheck output: `No vulnerabilities found.`

Detailed proof is posted below. Merge after #23; the notes describe its separately verified fix.
